### PR TITLE
fix #13 remove forward option from chat message menu items

### DIFF
--- a/lib/ui/chat/widgets/reaction/reaction_default_data.dart
+++ b/lib/ui/chat/widgets/reaction/reaction_default_data.dart
@@ -15,10 +15,9 @@ class DefaultData {
   ];
 
   // The default list of menuItems
-  static const List<MenuItem> menuItems = [reply, forward, copy, delete];
+  static const List<MenuItem> menuItems = [reply, copy, delete];
 
   static const List<MenuItem> myMessageMenuItems = [
-    forward,
     edit,
     copy,
     delete,
@@ -30,11 +29,6 @@ class DefaultData {
   );
 
   static const MenuItem copy = MenuItem(label: 'Copy', icon: CarbonIcons.copy);
-
-  static const MenuItem forward = MenuItem(
-    label: 'Forward',
-    icon: CarbonIcons.send,
-  );
 
   static const MenuItem edit = MenuItem(label: 'Edit', icon: CarbonIcons.edit);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The "Forward" option has been removed from the chat message menu. Only "Reply," "Copy," "Delete," and "Edit" options are now available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->