### PR TITLE
Fix/add relay sheet keyboard awarness

### DIFF
--- a/lib/ui/core/ui/custom_bottom_sheet.dart
+++ b/lib/ui/core/ui/custom_bottom_sheet.dart
@@ -24,6 +24,7 @@ class CustomBottomSheet {
     double blurSigma = 10.0,
     Duration transitionDuration = const Duration(milliseconds: 300),
     Curve curve = Curves.easeOutCubic,
+    bool keyboardAware = false,
   }) {
     return showGeneralDialog<T>(
       context: context,
@@ -120,6 +121,7 @@ class CustomBottomSheet {
                                   wrapContent: wrapContent,
                                   maxHeight: maxHeight,
                                   backgroundColor: context.colors.neutral,
+                                  keyboardAware: keyboardAware,
                                 ),
                               )
                               : _buildBottomSheetContent(
@@ -132,6 +134,7 @@ class CustomBottomSheet {
                                 wrapContent: wrapContent,
                                 maxHeight: maxHeight,
                                 backgroundColor: context.colors.neutral,
+                                keyboardAware: keyboardAware,
                               ),
                     ),
                   ],
@@ -154,6 +157,7 @@ class CustomBottomSheet {
     String? title,
     bool showCloseButton = true,
     bool showBackButton = false,
+    bool keyboardAware = false,
   }) {
     final contentWidget = Column(
       mainAxisSize: wrapContent ? MainAxisSize.min : MainAxisSize.max,
@@ -215,13 +219,29 @@ class CustomBottomSheet {
           maxHeight: maxHeight ?? 1.sh * 0.9, // Default max height
         ),
         decoration: BoxDecoration(color: backgroundColor),
-        child: contentWidget,
+        child:
+            keyboardAware
+                ? Padding(
+                  padding: EdgeInsets.only(
+                    bottom: MediaQuery.of(context).viewInsets.bottom,
+                  ),
+                  child: contentWidget,
+                )
+                : contentWidget,
       );
     } else {
       return Container(
         height: bottomSheetHeight!,
         decoration: BoxDecoration(color: backgroundColor),
-        child: contentWidget,
+        child:
+            keyboardAware
+                ? Padding(
+                  padding: EdgeInsets.only(
+                    bottom: MediaQuery.of(context).viewInsets.bottom,
+                  ),
+                  child: contentWidget,
+                )
+                : contentWidget,
       );
     }
   }

--- a/lib/ui/settings/network/add_relay_bottom_sheet.dart
+++ b/lib/ui/settings/network/add_relay_bottom_sheet.dart
@@ -33,6 +33,8 @@ class AddRelayBottomSheet extends ConsumerStatefulWidget {
       context: context,
       title: title,
       heightFactor: 0.35,
+      keyboardAware: true,
+      wrapContent: true,
       builder: (context) => AddRelayBottomSheet(onRelayAdded: onRelayAdded, title: title),
     );
   }
@@ -100,58 +102,56 @@ class _AddRelayBottomSheetState extends ConsumerState<AddRelayBottomSheet> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Padding(
-          padding: EdgeInsets.symmetric(horizontal: 24.w),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 24.w),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Enter your relay address',
+            style: TextStyle(
+              fontSize: 14.sp,
+              fontWeight: FontWeight.w500,
+              color: AppColors.glitch900,
+            ),
+          ),
+          Gap(8.h),
+          Row(
             children: [
-              Text(
-                'Enter your relay address',
-                style: TextStyle(
-                  fontSize: 14.sp,
-                  fontWeight: FontWeight.w500,
-                  color: AppColors.glitch900,
+              Expanded(
+                child: CustomTextField(
+                  textController: _relayUrlController,
+                  hintText: 'wss://',
+                  padding: EdgeInsets.zero,
                 ),
               ),
-              Gap(8.h),
-              Row(
-                children: [
-                  Expanded(
-                    child: CustomTextField(
-                      textController: _relayUrlController,
-                      hintText: 'wss://',
-                      padding: EdgeInsets.zero,
-                    ),
-                  ),
-                  Gap(8.w),
-                  CustomIconButton(
-                    onTap: _pasteFromClipboard,
-                    iconPath: AssetsPaths.icPaste,
-                  ),
-                ],
+              Gap(8.w),
+              CustomIconButton(
+                onTap: _pasteFromClipboard,
+                iconPath: AssetsPaths.icPaste,
               ),
-              Gap(16.h),
-              if (!_isUrlValid && _relayUrlController.text.isNotEmpty) ...[
-                Text(
-                  'Invalid format: must start with wss://',
-                  style: TextStyle(
-                    fontSize: 14.sp,
-                    color: AppColors.colorDC2626,
-                  ),
-                ),
-              ],
-              Gap(16.h),
             ],
           ),
-        ),
-        AppFilledButton(
-          onPressed: _isUrlValid && !_isAdding ? _addRelay : null,
-          loading: _isAdding,
-          title: widget.title,
-        ),
-      ],
+          Gap(16.h),
+          if (!_isUrlValid && _relayUrlController.text.isNotEmpty) ...[
+            Text(
+              'Invalid format: must start with wss://',
+              style: TextStyle(
+                fontSize: 14.sp,
+                color: AppColors.colorDC2626,
+              ),
+            ),
+            Gap(8.h),
+          ],
+          AppFilledButton(
+            onPressed: _isUrlValid && !_isAdding ? _addRelay : null,
+            loading: _isAdding,
+            title: widget.title,
+          ),
+          Gap(16.h),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Fixed the issue where the input field was hidden below the keyboard when adding relays. 

**Changes made:**
- Added `keyboardAware` parameter to `CustomBottomSheet` class to handle keyboard awareness
- Updated `AddRelayBottomSheet` to use `keyboardAware: true` and `wrapContent: true` properties 
- Refactored layout structure in `_AddRelayBottomSheetState` to use `Padding` widget instead of `Column` for better alignment
- Added `mainAxisSize: MainAxisSize.min` to the `Column` widget for better size control
- Updated various API files (`accounts.dart`, `relays.dart`, `utils.dart`) with code refactoring for better readability

The solution ensures that when the keyboard appears, the bottom sheet automatically adjusts its position so the input field remains visible and accessible to users.

**Follow-up improvements:**
Future enhancements to `CustomBottomSheet` could include more sophisticated keyboard handling with smooth animations during keyboard transitions, automatic detection of text inputs to enable keyboard awareness by default, and different keyboard avoidance modes (resize vs scroll) to provide even better user experience across all bottom sheets in the app.

**Fixes:** #186

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Additional information

Before:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/0bee50ba-20fd-48c2-9c69-323edb81e6b4" /> <img width="250" alt="image" src="https://github.com/user-attachments/assets/af6cbc66-c666-4c9c-8b34-ab70c49bcdd8" />

After: 
<img width="250" alt="image" src="https://github.com/user-attachments/assets/ed1b46d5-1bd1-4ebe-a960-dfaf99495a1b" />
