### PR TITLE
Hide mute and search chat buttons and remove nostr_group_id npub from group info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 ### Removed
+- Remove (for now) the mute and search chat controls from group info screens.
+- Remove incorrect group npub from the group info screen.
 
 ### Fixed
 - Fixed profile picture upload issue.

--- a/lib/ui/chat/chat_info/dm_chat_info.dart
+++ b/lib/ui/chat/chat_info/dm_chat_info.dart
@@ -210,35 +210,36 @@ class _DMChatInfoState extends ConsumerState<DMChatInfo> {
                     },
           ),
           Gap(12.h),
-          Row(
-            spacing: 12.w,
-            children: [
-              Expanded(
-                child: AppFilledButton.icon(
-                  visualState: AppButtonVisualState.secondary,
-                  icon: SvgPicture.asset(
-                    AssetsPaths.icSearch,
-                    width: 14.w,
-                    colorFilter: ColorFilter.mode(context.colors.primary, BlendMode.srcIn),
-                  ),
-                  label: const Text('Search Chat'),
-                  onPressed: () {},
-                ),
-              ),
-              Expanded(
-                child: AppFilledButton.icon(
-                  visualState: AppButtonVisualState.secondary,
-                  icon: SvgPicture.asset(
-                    AssetsPaths.icMutedNotification,
-                    width: 14.w,
-                    colorFilter: ColorFilter.mode(context.colors.primary, BlendMode.srcIn),
-                  ),
-                  label: const Text('Mute Chat'),
-                  onPressed: () {},
-                ),
-              ),
-            ],
-          ),
+          // TODO: Reenable when we have a search and mute features
+          // Row(
+          //   spacing: 12.w,
+          //   children: [
+          //     Expanded(
+          //       child: AppFilledButton.icon(
+          //         visualState: AppButtonVisualState.secondary,
+          //         icon: SvgPicture.asset(
+          //           AssetsPaths.icSearch,
+          //           width: 14.w,
+          //           colorFilter: ColorFilter.mode(context.colors.primary, BlendMode.srcIn),
+          //         ),
+          //         label: const Text('Search Chat'),
+          //         onPressed: () {},
+          //       ),
+          //     ),
+          //     Expanded(
+          //       child: AppFilledButton.icon(
+          //         visualState: AppButtonVisualState.secondary,
+          //         icon: SvgPicture.asset(
+          //           AssetsPaths.icMutedNotification,
+          //           width: 14.w,
+          //           colorFilter: ColorFilter.mode(context.colors.primary, BlendMode.srcIn),
+          //         ),
+          //         label: const Text('Mute Chat'),
+          //         onPressed: () {},
+          //       ),
+          //     ),
+          //   ],
+          // ),
         ],
       ),
     );

--- a/lib/ui/chat/chat_info/group_chat_info.dart
+++ b/lib/ui/chat/chat_info/group_chat_info.dart
@@ -120,47 +120,39 @@ class _GroupChatInfoState extends ConsumerState<GroupChatInfo> {
                 fontSize: 14.sp,
               ),
             ),
-            Gap(16.h),
-            Text(
-              '${groupNpub ?? groupDetails?.nostrGroupId}'.formatPublicKey(),
-              textAlign: TextAlign.center,
-              style: context.textTheme.bodyMedium?.copyWith(
-                color: context.colors.mutedForeground,
-                fontSize: 14.sp,
-              ),
-            ),
             Gap(32.h),
 
-            Row(
-              spacing: 12.w,
-              children: [
-                Expanded(
-                  child: AppFilledButton.icon(
-                    visualState: AppButtonVisualState.secondary,
-                    icon: SvgPicture.asset(
-                      AssetsPaths.icSearch,
-                      width: 14.w,
-                      colorFilter: ColorFilter.mode(context.colors.primary, BlendMode.srcIn),
-                    ),
-                    label: const Text('Search Chat'),
-                    onPressed: () {},
-                  ),
-                ),
-                Expanded(
-                  child: AppFilledButton.icon(
-                    visualState: AppButtonVisualState.secondary,
-                    icon: SvgPicture.asset(
-                      AssetsPaths.icMutedNotification,
-                      width: 14.w,
-                      colorFilter: ColorFilter.mode(context.colors.primary, BlendMode.srcIn),
-                    ),
-                    label: const Text('Mute Chat'),
-                    onPressed: () {},
-                  ),
-                ),
-              ],
-            ),
-            Gap(32.h),
+            // TODO: Reenable when we have a search and mute features
+            // Row(
+            //   spacing: 12.w,
+            //   children: [
+            //     Expanded(
+            //       child: AppFilledButton.icon(
+            //         visualState: AppButtonVisualState.secondary,
+            //         icon: SvgPicture.asset(
+            //           AssetsPaths.icSearch,
+            //           width: 14.w,
+            //           colorFilter: ColorFilter.mode(context.colors.primary, BlendMode.srcIn),
+            //         ),
+            //         label: const Text('Search Chat'),
+            //         onPressed: () {},
+            //       ),
+            //     ),
+            //     Expanded(
+            //       child: AppFilledButton.icon(
+            //         visualState: AppButtonVisualState.secondary,
+            //         icon: SvgPicture.asset(
+            //           AssetsPaths.icMutedNotification,
+            //           width: 14.w,
+            //           colorFilter: ColorFilter.mode(context.colors.primary, BlendMode.srcIn),
+            //         ),
+            //         label: const Text('Mute Chat'),
+            //         onPressed: () {},
+            //       ),
+            //     ),
+            //   ],
+            // ),
+            // Gap(32.h),
 
             if (isLoadingMembers)
               const CircularProgressIndicator()

--- a/lib/ui/chat/chat_info/group_chat_info.dart
+++ b/lib/ui/chat/chat_info/group_chat_info.dart
@@ -153,7 +153,6 @@ class _GroupChatInfoState extends ConsumerState<GroupChatInfo> {
             //   ],
             // ),
             // Gap(32.h),
-
             if (isLoadingMembers)
               const CircularProgressIndicator()
             else if (groupMembers.isNotEmpty) ...[


### PR DESCRIPTION
## Description

- Hide mute and search chat controls since they currently don't work. We'll bring them back in a future release. Fixes #311 
- Remove npub (generated from the group's nostr_group_id value) from the group info page.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Checklist

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [x] Updated the `CHANGELOG.md` file with your changes
