### PR TITLE
fix(navigation): fix connect profile back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show the npub of each user on the contacts list
 - Add developer settings screen with some basic cache management functions
 - Confirmation dialog when signing out
+- Fixed back navigation when connecting another account 
 
 ### Changed
 
@@ -41,4 +42,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2025-07-09
 
 Initial release of White Noise!
-


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
This PR fixes Issue #181. When swithcing profiles from the settings screen, the back button in the second sheet didn't go back to the first sheet, instead the sheet was closed.


Also while testing this I noticed that in the case of logout with more than 2 accounts, the back button of the connect another account sheet worked fine but the switch profile account was still visible behind. 


The change consists on removing the navigation pop when clicking the button that opens the second sheet and instead hiding the visibility of first sheet conditioned to if the second sheet is open. 

Short video of how it works now for both cases (switching directly from the profile switch and switching because of logout)


https://github.com/user-attachments/assets/ec00ba23-d0a9-4c93-ae0e-0bb92d3b3512



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [x] Updated the `CHANGELOG.md` file with your changes
