### PR TITLE
303 reactions dont show up for other participants

### DIFF
--- a/lib/config/providers/chat_provider.dart
+++ b/lib/config/providers/chat_provider.dart
@@ -376,22 +376,60 @@ class ChatNotifier extends Notifier<ChatState> {
       );
 
       final currentMessages = state.groupMessages[groupId] ?? [];
-      if (newMessages.length > currentMessages.length) {
-        final newMessagesOnly = newMessages.skip(currentMessages.length).toList();
 
-        state = state.copyWith(
-          groupMessages: {
-            ...state.groupMessages,
-            groupId: [...currentMessages, ...newMessagesOnly],
-          },
-        );
+      // Check for changes beyond just message count (reactions, edits, etc.)
+      bool hasChanges = false;
 
-        // Update group order when new messages are received
+      if (newMessages.length != currentMessages.length) {
+        // New or deleted messages
+        hasChanges = true;
+      } else if (newMessages.isNotEmpty && currentMessages.isNotEmpty) {
+        // Check if any message content or reactions have changed
+        for (int i = 0; i < newMessages.length; i++) {
+          final newMsg = newMessages[i];
+          final currentMsg = currentMessages[i];
+
+          // Compare message content and reactions
+          if (newMsg.content != currentMsg.content ||
+              newMsg.reactions.length != currentMsg.reactions.length ||
+              !_areReactionsEqual(newMsg.reactions, currentMsg.reactions)) {
+            hasChanges = true;
+            break;
+          }
+        }
+      }
+
+      if (hasChanges) {
+        if (newMessages.length > currentMessages.length) {
+          // Add only new messages to preserve performance
+          final newMessagesOnly = newMessages.skip(currentMessages.length).toList();
+
+          state = state.copyWith(
+            groupMessages: {
+              ...state.groupMessages,
+              groupId: [...currentMessages, ...newMessagesOnly],
+            },
+          );
+
+          _logger.info(
+            'ChatProvider: Added ${newMessagesOnly.length} new messages for group $groupId',
+          );
+        } else {
+          // Replace all messages when there are content changes (reactions, edits, etc.)
+          state = state.copyWith(
+            groupMessages: {
+              ...state.groupMessages,
+              groupId: newMessages,
+            },
+          );
+
+          _logger.info(
+            'ChatProvider: Updated messages with content changes for group $groupId',
+          );
+        }
+
+        // Update group order when messages are updated
         _updateGroupOrderForNewMessage(groupId);
-
-        _logger.info(
-          'ChatProvider: Added ${newMessagesOnly.length} new messages for group $groupId',
-        );
       }
     } catch (e, st) {
       _logger.severe('ChatProvider.checkForNewMessages', e, st);
@@ -836,6 +874,51 @@ class ChatNotifier extends Notifier<ChatState> {
     final now = DateTime.now();
 
     ref.read(groupsProvider.notifier).updateGroupActivityTime(groupId, now);
+  }
+
+  /// Helper method to compare if two reaction lists are equal
+  bool _areReactionsEqual(List<Reaction> reactions1, List<Reaction> reactions2) {
+    if (reactions1.length != reactions2.length) {
+      return false;
+    }
+
+    // Create maps of emoji -> list of user public keys for comparison
+    final map1 = <String, List<String>>{};
+    final map2 = <String, List<String>>{};
+
+    for (final reaction in reactions1) {
+      map1.putIfAbsent(reaction.emoji, () => []).add(reaction.user.publicKey);
+    }
+
+    for (final reaction in reactions2) {
+      map2.putIfAbsent(reaction.emoji, () => []).add(reaction.user.publicKey);
+    }
+
+    // Compare the maps
+    if (map1.keys.length != map2.keys.length) {
+      return false;
+    }
+
+    for (final emoji in map1.keys) {
+      if (!map2.containsKey(emoji)) {
+        return false;
+      }
+
+      final users1 = map1[emoji]!..sort();
+      final users2 = map2[emoji]!..sort();
+
+      if (users1.length != users2.length) {
+        return false;
+      }
+
+      for (int i = 0; i < users1.length; i++) {
+        if (users1[i] != users2[i]) {
+          return false;
+        }
+      }
+    }
+
+    return true;
   }
 }
 

--- a/lib/config/providers/chat_provider.dart
+++ b/lib/config/providers/chat_provider.dart
@@ -582,8 +582,6 @@ class ChatNotifier extends Notifier<ChatState> {
       _logger.info('ChatProvider: Adding reaction "$reaction" to message ${message.id}');
 
       // Create reaction content (emoji) - NIP-25 compliant
-      // Content MUST include user-generated-content indicating the value of the reaction
-      // (conventionally +, -, or an emoji)
       final reactionContent = reaction; // This should be an emoji like 👍, ❤️, etc.
 
       // Use the message's actual kind (now stored in MessageModel)
@@ -620,7 +618,7 @@ class ChatNotifier extends Notifier<ChatState> {
     } catch (e, st) {
       _logger.severe('ChatProvider.updateMessageReaction', e, st);
 
-      String errorMessage = 'Failed to add reaction';
+      String errorMessage = 'Failed to update reaction';
       if (e is WhitenoiseError) {
         try {
           errorMessage = await whitenoiseErrorToString(error: e);

--- a/lib/ui/chat/services/chat_dialog_service.dart
+++ b/lib/ui/chat/services/chat_dialog_service.dart
@@ -37,10 +37,6 @@ class ChatDialogService {
                 backgroundColor: context.colors.primaryForeground,
                 columns: 7,
                 emojiSizeMax: 32.0,
-                verticalSpacing: 0,
-                horizontalSpacing: 0,
-                gridPadding: EdgeInsets.zero,
-                recentsLimit: 28,
                 noRecents: Text(
                   'No Recents',
                   style: TextStyle(
@@ -63,7 +59,6 @@ class ChatDialogService {
                 iconColorSelected: context.colors.primary,
                 indicatorColor: context.colors.primary,
                 backspaceColor: context.colors.mutedForeground,
-                categoryIcons: const CategoryIcons(),
               ),
               searchViewConfig: SearchViewConfig(
                 backgroundColor: context.colors.primaryForeground,

--- a/lib/ui/chat/widgets/reaction/reactions_dialog_widget.dart
+++ b/lib/ui/chat/widgets/reaction/reactions_dialog_widget.dart
@@ -187,10 +187,10 @@ class _ReactionsDialogWidgetState extends State<ReactionsDialogWidget> {
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       spacing: 6.w,
       children: [
-        Gap(24.w),
+        Gap(12.w),
         for (var reaction in widget.reactions) _buildReactionItem(reaction),
         _buildAddReactionButton(),
-        Gap(24.w),
+        Gap(12.w),
       ],
     );
   }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

Fix #303: Real-time reaction 
  updates for other participants

  Problem

  Reactions sent by users were not
  appearing for other participants
  until they left and returned to the
   chat screen. The polling mechanism
   only detected new message count
  changes, ignoring content updates
  like reactions.

  Solution

  Enhanced the checkForNewMessages()
  method in ChatProvider to detect
  reaction changes during polling:

  Key Changes

  1. Enhanced Change Detection 
  (chat_provider.dart:380-400)
  - Added content comparison beyond
  just message count
  - Now detects reactions, message
  edits, and other content changes
  - Compares message content and
  reaction counts between polling
  cycles

  2. Added Reaction Comparison Logic 
  (chat_provider.dart:879-922)
  - New _areReactionsEqual() helper
  method for detailed reaction
  comparison
  - Compares reactions by emoji and
  user public keys
  - Handles cases where reactions are
   added/removed/changed

  3. Improved Update Performance 
  (chat_provider.dart:402-433)
  - Preserves append-only behavior
  for new messages (optimal
  performance)
  - Replaces all messages only when
  content changes are detected
  - Proper logging for both scenarios

  Technical Details

  - Before: Polling only checked
  newMessages.length > 
  currentMessages.length
  - After: Polling detects ANY
  message changes including reactions
   via content comparison
  - Performance: Maintains efficiency
   by only doing full replacement
  when needed
  - Real-time: Reactions now appear
  within 2 seconds (polling interval)
   for all participants

  Testing

  - ✅ Reactions appear in real-time
  for other participants
logging preserved

  Closes #303

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes
