### PR TITLE
Fix/linter issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,4 +64,4 @@ jobs:
       run: cd rust && cargo clippy --package rust_lib_whitenoise -- -D warnings
 
     - name: Flutter analyze (errors only)
-      run: flutter analyze --fatal-infos || true
+      run: flutter analyze --fatal-infos

--- a/lib/config/providers/relay_provider.dart
+++ b/lib/config/providers/relay_provider.dart
@@ -85,11 +85,7 @@ class NormalRelaysNotifier extends Notifier<RelayState> {
       // If no relays found, log this information
       if (relayUrls.isEmpty) {
         _logger.warning('NormalRelaysNotifier: No relays found for user.');
-        state = state.copyWith(
-          relays: [],
-          isLoading: false,
-          error: null, // Clear any previous errors
-        );
+        state = state.copyWith(relays: [], isLoading: false);
         return;
       }
 
@@ -113,7 +109,7 @@ class NormalRelaysNotifier extends Notifier<RelayState> {
       );
 
       _logger.info('NormalRelaysNotifier: Successfully loaded ${relayInfos.length} relays');
-      state = state.copyWith(relays: relayInfos, isLoading: false, error: null);
+      state = state.copyWith(relays: relayInfos, isLoading: false);
     } catch (e, stackTrace) {
       _logger.severe('NormalRelaysNotifier: Error loading relays: $e', e, stackTrace);
       state = state.copyWith(
@@ -257,11 +253,7 @@ class InboxRelaysNotifier extends Notifier<RelayState> {
       // If no relays found, log this information
       if (relayUrls.isEmpty) {
         _logger.warning('InboxRelaysNotifier: No inbox relays found for user.');
-        state = state.copyWith(
-          relays: [],
-          isLoading: false,
-          error: null, // Clear any previous errors
-        );
+        state = state.copyWith(relays: [], isLoading: false);
         return;
       }
 
@@ -285,7 +277,7 @@ class InboxRelaysNotifier extends Notifier<RelayState> {
       );
 
       _logger.info('InboxRelaysNotifier: Successfully loaded ${relayInfos.length} relays');
-      state = state.copyWith(relays: relayInfos, isLoading: false, error: null);
+      state = state.copyWith(relays: relayInfos, isLoading: false);
     } catch (e, stackTrace) {
       _logger.severe('InboxRelaysNotifier: Error loading relays: $e', e, stackTrace);
       state = state.copyWith(
@@ -434,7 +426,6 @@ class KeyPackageRelaysNotifier extends Notifier<RelayState> {
         state = state.copyWith(
           relays: [],
           isLoading: false,
-          error: null, // Clear any previous errors
         );
         return;
       }
@@ -454,7 +445,7 @@ class KeyPackageRelaysNotifier extends Notifier<RelayState> {
       );
 
       _logger.info('KeyPackageRelaysNotifier: Successfully loaded ${relayInfos.length} relays');
-      state = state.copyWith(relays: relayInfos, isLoading: false, error: null);
+      state = state.copyWith(relays: relayInfos, isLoading: false);
     } catch (e, stackTrace) {
       _logger.severe('KeyPackageRelaysNotifier: Error loading relays: $e', e, stackTrace);
       state = state.copyWith(

--- a/lib/config/providers/relay_status_provider.dart
+++ b/lib/config/providers/relay_status_provider.dart
@@ -92,7 +92,7 @@ class RelayStatusNotifier extends Notifier<RelayStatusState> {
       }
 
       _logger.info('RelayStatusNotifier: Successfully loaded ${statusMap.length} relay statuses');
-      state = state.copyWith(relayStatuses: statusMap, isLoading: false, error: null);
+      state = state.copyWith(relayStatuses: statusMap, isLoading: false);
     } catch (e, stackTrace) {
       _logger.severe('RelayStatusNotifier: Error loading relay statuses: $e', e, stackTrace);
       state = state.copyWith(

--- a/lib/ui/auth_flow/qr_scanner_bottom_sheet.dart
+++ b/lib/ui/auth_flow/qr_scanner_bottom_sheet.dart
@@ -55,7 +55,7 @@ class _QRScannerBottomSheetState extends State<QRScannerBottomSheet> {
         // QR Code Scanner Area
         ClipRRect(
           borderRadius: BorderRadius.circular(8.r),
-          child: Container(
+          child: SizedBox(
             height: 300.h,
             width: double.infinity,
             child:

--- a/lib/ui/settings/network/add_relay_bottom_sheet.dart
+++ b/lib/ui/settings/network/add_relay_bottom_sheet.dart
@@ -99,7 +99,7 @@ class _AddRelayBottomSheetState extends ConsumerState<AddRelayBottomSheet> {
     try {
       final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
       if (clipboardData?.text != null) {
-        String pastedText = clipboardData!.text!.trim();
+        final String pastedText = clipboardData!.text!.trim();
 
         // If pasted text already starts with wss:// or ws://, use it as is
         // Otherwise, append it to wss://

--- a/lib/ui/settings/network/network_screen.dart
+++ b/lib/ui/settings/network/network_screen.dart
@@ -34,24 +34,24 @@ class _NetworkScreenState extends ConsumerState<NetworkScreen> {
 
   Future<void> _refreshData() async {
     try {
-      print('NetworkScreen: Starting to refresh relay data');
+      debugPrint('NetworkScreen: Starting to refresh relay data');
 
       // First refresh the relay status provider
-      print('NetworkScreen: Loading relay statuses');
+      debugPrint('NetworkScreen: Loading relay statuses');
       await ref.read(relayStatusProvider.notifier).loadRelayStatuses();
 
       // Then refresh all relay providers
-      print('NetworkScreen: Loading all relay providers');
+      debugPrint('NetworkScreen: Loading all relay providers');
       await Future.wait([
         ref.read(normalRelaysProvider.notifier).loadRelays(),
         ref.read(inboxRelaysProvider.notifier).loadRelays(),
         ref.read(keyPackageRelaysProvider.notifier).loadRelays(),
       ]);
 
-      print('NetworkScreen: Successfully refreshed all relay data');
+      debugPrint('NetworkScreen: Successfully refreshed all relay data');
     } catch (e, stackTrace) {
-      print('NetworkScreen: Error refreshing relay data: $e');
-      print('NetworkScreen: Stack trace: $stackTrace');
+      debugPrint('NetworkScreen: Error refreshing relay data: $e');
+      debugPrint('NetworkScreen: Stack trace: $stackTrace');
     }
   }
 

--- a/rust_builder/cargokit/gradle/plugin.gradle
+++ b/rust_builder/cargokit/gradle/plugin.gradle
@@ -114,7 +114,7 @@ class CargoKitPlugin implements Plugin<Project> {
         project.extensions.create("cargokit", CargoKitExtension)
 
         if (plugin == null) {
-            print("Flutter plugin not found, CargoKit plugin will not be applied.")
+            debugPrint("Flutter plugin not found, CargoKit plugin will not be applied.")
             return;
         }
 


### PR DESCRIPTION
## Description
When I run just precommit in master branch, it failed, but ci checks in the repo were passing because in the github action it is forced to return always true. Although in the PR  template is a checkbox to remind to run just precommit, sometimes it is checked when it is actually not passing.  In my opinion it would be better that the ci failed when linter errors are introduced. 

These were the current warnings on master:

<img width="897" height="666" alt="Captura de pantalla 2025-07-18 a la(s) 1 56 02 p m" src="https://github.com/user-attachments/assets/ed027340-9bfd-4514-8ae7-618ca959d565" />

**This PR:**
- Replaces  prints with debug prints
- Removes redundant args when there are equal to default value
- Replaces a container with a sized box
- Removes an || true in ci github action that forced flutter analyze to pass always, even when it had errors.

After this changes, flutter analyze passes.

<img width="842" height="297" alt="Captura de pantalla 2025-07-18 a la(s) 1 57 21 p m" src="https://github.com/user-attachments/assets/df2f74d8-0ea9-42a1-a544-f23ab00f380a" />

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


## Checklist
<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes
