### PR TITLE
Re-use the avatar component in edit profile settings

### DIFF
--- a/lib/ui/chat/widgets/chat_contact_avatar.dart
+++ b/lib/ui/chat/widgets/chat_contact_avatar.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:supa_carbon_icons/supa_carbon_icons.dart';
 import 'package:whitenoise/ui/core/themes/src/app_theme.dart';
@@ -42,7 +43,7 @@ class ContactAvatar extends StatelessWidget {
   }
 
   Widget _buildChild(BuildContext context) {
-    // First priority: image if URL is not empty (network or asset)
+    // First priority: image if URL is not empty (network, local file, or asset)
     if (imageUrl.isNotEmpty) {
       // Try network image first
       if (imageUrl.startsWith('http')) {
@@ -54,7 +55,16 @@ class ContactAvatar extends StatelessWidget {
           errorBuilder: (context, error, stackTrace) => _buildFallbackAvatar(context),
         );
       }
-
+      // Try local file image
+      if (File(imageUrl).existsSync()) {
+        return Image.file(
+          File(imageUrl),
+          width: size,
+          height: size,
+          fit: BoxFit.cover,
+          errorBuilder: (context, error, stackTrace) => _buildFallbackAvatar(context),
+        );
+      }
       // Try asset image
       return Image.asset(
         imageUrl,
@@ -65,7 +75,6 @@ class ContactAvatar extends StatelessWidget {
         errorBuilder: (context, error, stackTrace) => _buildFallbackAvatar(context),
       );
     }
-
     // Second priority: fallback to displayName first letter or default avatar
     return _buildFallbackAvatar(context);
   }

--- a/lib/ui/chat/widgets/chat_contact_avatar.dart
+++ b/lib/ui/chat/widgets/chat_contact_avatar.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:whitenoise/ui/core/themes/src/app_theme.dart';
 import 'package:supa_carbon_icons/supa_carbon_icons.dart';
+import 'package:whitenoise/ui/core/themes/src/app_theme.dart';
 
 class ContactAvatar extends StatelessWidget {
   const ContactAvatar({

--- a/lib/ui/chat/widgets/chat_contact_avatar.dart
+++ b/lib/ui/chat/widgets/chat_contact_avatar.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/app_theme.dart';
+import 'package:supa_carbon_icons/supa_carbon_icons.dart';
 
 class ContactAvatar extends StatelessWidget {
   const ContactAvatar({
@@ -88,10 +88,12 @@ class ContactAvatar extends StatelessWidget {
     // Final fallback: Default avatar asset with proper padding
     return Padding(
       padding: EdgeInsets.all(size * 0.25),
-      child: Image.asset(
-        AssetsPaths.icAvatar,
-        fit: BoxFit.contain,
-        color: context.colors.primary,
+      child: Center(
+        child: Icon(
+          CarbonIcons.user,
+          size: size * 0.4,
+          color: context.colors.primary,
+        ),
       ),
     );
   }

--- a/lib/ui/settings/profile/edit_profile_screen.dart
+++ b/lib/ui/settings/profile/edit_profile_screen.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:whitenoise/config/extensions/toast_extension.dart';
 import 'package:whitenoise/config/providers/profile_provider.dart';
+import 'package:whitenoise/config/states/profile_state.dart';
 import 'package:whitenoise/ui/chat/widgets/chat_contact_avatar.dart';
 import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
@@ -15,7 +16,6 @@ import 'package:whitenoise/ui/core/ui/app_button.dart';
 import 'package:whitenoise/ui/core/ui/app_text_form_field.dart';
 import 'package:whitenoise/ui/core/ui/whitenoise_dialog.dart';
 import 'package:whitenoise/ui/settings/profile/widgets/edit_icon.dart';
-import 'package:whitenoise/config/states/profile_state.dart';
 
 class EditProfileScreen extends ConsumerStatefulWidget {
   const EditProfileScreen({super.key});

--- a/lib/ui/settings/profile/edit_profile_screen.dart
+++ b/lib/ui/settings/profile/edit_profile_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/ui/settings/profile/edit_profile_screen.dart
+++ b/lib/ui/settings/profile/edit_profile_screen.dart
@@ -7,10 +7,10 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
-import 'package:supa_carbon_icons/supa_carbon_icons.dart';
 
 import 'package:whitenoise/config/extensions/toast_extension.dart';
 import 'package:whitenoise/config/providers/profile_provider.dart';
+import 'package:whitenoise/ui/chat/widgets/chat_contact_avatar.dart';
 import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
 import 'package:whitenoise/ui/core/ui/app_button.dart';
@@ -150,55 +150,14 @@ class _EditProfileScreenState extends ConsumerState<EditProfileScreen> {
                                       valueListenable: _displayNameController,
                                       builder: (context, value, child) {
                                         final displayText = value.text.trim();
-                                        final firstLetter =
-                                            displayText.isNotEmpty
-                                                ? displayText[0].toUpperCase()
-                                                : '';
                                         final selectedImagePath =
-                                            ref.watch(profileProvider).value?.selectedImagePath ??
-                                            '';
+                                            ref.watch(profileProvider).value?.selectedImagePath;
                                         final profilePicture =
                                             ref.watch(profileProvider).value?.picture ?? '';
-                                        return ClipOval(
-                                          child: Container(
-                                            width: 96.w,
-                                            height: 96.w,
-                                            alignment: Alignment.center,
-                                            decoration: BoxDecoration(
-                                              color: context.colors.primarySolid,
-                                              image:
-                                                  selectedImagePath.isNotEmpty
-                                                      ? DecorationImage(
-                                                        image: FileImage(File(selectedImagePath)),
-                                                        fit: BoxFit.cover,
-                                                      )
-                                                      : null,
-                                            ),
-                                            child:
-                                                profilePicture.isNotEmpty &&
-                                                        selectedImagePath.isEmpty
-                                                    ? Image.network(
-                                                      profilePicture,
-                                                      fit: BoxFit.cover,
-                                                    )
-                                                    : profilePicture.isEmpty &&
-                                                        selectedImagePath.isEmpty
-                                                    ? (firstLetter.isNotEmpty
-                                                        ? Text(
-                                                          firstLetter,
-                                                          style: TextStyle(
-                                                            fontSize: 32.sp,
-                                                            fontWeight: FontWeight.w700,
-                                                            color: context.colors.primaryForeground,
-                                                          ),
-                                                        )
-                                                        : Icon(
-                                                          CarbonIcons.user,
-                                                          size: 32.sp,
-                                                          color: context.colors.primaryForeground,
-                                                        ))
-                                                    : null,
-                                          ),
+                                        return ContactAvatar(
+                                          imageUrl: selectedImagePath ?? profilePicture,
+                                          displayName: displayText,
+                                          size: 96.w,
                                         );
                                       },
                                     ),

--- a/lib/ui/settings/profile/edit_profile_screen.dart
+++ b/lib/ui/settings/profile/edit_profile_screen.dart
@@ -15,6 +15,7 @@ import 'package:whitenoise/ui/core/ui/app_button.dart';
 import 'package:whitenoise/ui/core/ui/app_text_form_field.dart';
 import 'package:whitenoise/ui/core/ui/whitenoise_dialog.dart';
 import 'package:whitenoise/ui/settings/profile/widgets/edit_icon.dart';
+import 'package:whitenoise/config/states/profile_state.dart';
 
 class EditProfileScreen extends ConsumerStatefulWidget {
   const EditProfileScreen({super.key});
@@ -147,13 +148,11 @@ class _EditProfileScreenState extends ConsumerState<EditProfileScreen> {
                                     ValueListenableBuilder<TextEditingValue>(
                                       valueListenable: _displayNameController,
                                       builder: (context, value, child) {
-                                        final selectedImagePath =
-                                            ref.watch(profileProvider).value?.selectedImagePath;
-                                        final profilePicture =
-                                            ref.watch(profileProvider).value?.picture ?? '';
+                                        final imageUrl = _getProfileImageUrl(profile);
+                                        final displayName = value.text.trim();
                                         return ContactAvatar(
-                                          imageUrl: selectedImagePath ?? profilePicture,
-                                          displayName: value.text.trim(),
+                                          imageUrl: imageUrl,
+                                          displayName: displayName,
                                           size: 96.w,
                                         );
                                       },
@@ -333,6 +332,18 @@ class _EditProfileScreenState extends ConsumerState<EditProfileScreen> {
       ),
     );
   }
+}
+
+String _getProfileImageUrl(ProfileState? profile) {
+  final selectedImagePath = profile?.selectedImagePath;
+  final profilePicture = profile?.picture ?? '';
+  if (selectedImagePath != null && selectedImagePath.isNotEmpty) {
+    return selectedImagePath;
+  }
+  if (profilePicture.isNotEmpty) {
+    return profilePicture;
+  }
+  return '';
 }
 
 class FallbackProfileImageWidget extends StatelessWidget {

--- a/lib/ui/settings/profile/edit_profile_screen.dart
+++ b/lib/ui/settings/profile/edit_profile_screen.dart
@@ -147,14 +147,13 @@ class _EditProfileScreenState extends ConsumerState<EditProfileScreen> {
                                     ValueListenableBuilder<TextEditingValue>(
                                       valueListenable: _displayNameController,
                                       builder: (context, value, child) {
-                                        final displayText = value.text.trim();
                                         final selectedImagePath =
                                             ref.watch(profileProvider).value?.selectedImagePath;
                                         final profilePicture =
                                             ref.watch(profileProvider).value?.picture ?? '';
                                         return ContactAvatar(
                                           imageUrl: selectedImagePath ?? profilePicture,
-                                          displayName: displayText,
+                                          displayName: value.text.trim(),
                                           size: 96.w,
                                         );
                                       },


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->
## Description

Seems like dark mode and light mode aren't both supported by the avatar empty state. This caused light mode not to have an empty state

Refactoring the code so that we use an icon component rather than a png asset for the profile Icon



Before:

https://github.com/user-attachments/assets/b6cdc344-e280-4067-8349-56469f243a82



After:

The UI now uses an svg for the profile icon empty state, so it works correctly both in light and dark mode

https://github.com/user-attachments/assets/f7b34b44-c16c-46fb-a7c1-0ca34a60bf80
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes
