### PR TITLE
Fix #257 - Wrap message content in IntrinsicWidth

### DIFF
--- a/lib/ui/chat/widgets/message_widget.dart
+++ b/lib/ui/chat/widgets/message_widget.dart
@@ -64,30 +64,31 @@ class MessageWidget extends StatelessWidget {
               crossAxisAlignment: message.isMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
               children: [
-              if (isGroupMessage && !isSameSenderAsNext && !message.isMe) ...[
-                Text(
-                  message.sender.displayName,
-                  style: TextStyle(
-                    fontSize: 12.sp,
-                    fontWeight: FontWeight.w600,
-                    color: context.colors.mutedForeground,
+                if (isGroupMessage && !isSameSenderAsNext && !message.isMe) ...[
+                  Text(
+                    message.sender.displayName,
+                    style: TextStyle(
+                      fontSize: 12.sp,
+                      fontWeight: FontWeight.w600,
+                      color: context.colors.mutedForeground,
+                    ),
                   ),
+                  Gap(4.h),
+                ],
+                ReplyBox(
+                  replyingTo: message.replyTo,
+                  onTap:
+                      message.replyTo != null ? () => onReplyTap?.call(message.replyTo!.id) : null,
                 ),
-                Gap(4.h),
-              ],
-              ReplyBox(
-                replyingTo: message.replyTo,
-                onTap: message.replyTo != null ? () => onReplyTap?.call(message.replyTo!.id) : null,
-              ),
-              _buildMessageWithTimestamp(
-                context,
-                constraints.maxWidth - 16.w,
-              ),
+                _buildMessageWithTimestamp(
+                  context,
+                  constraints.maxWidth - 16.w,
+                ),
 
-              if (message.reactions.isNotEmpty) ...[
-                SizedBox(height: 4.h),
-                ReactionsRow(message: message, onReactionTap: onReactionTap, context: context),
-              ],
+                if (message.reactions.isNotEmpty) ...[
+                  SizedBox(height: 4.h),
+                  ReactionsRow(message: message, onReactionTap: onReactionTap, context: context),
+                ],
               ],
             ),
           ),

--- a/lib/ui/chat/widgets/message_widget.dart
+++ b/lib/ui/chat/widgets/message_widget.dart
@@ -54,15 +54,16 @@ class MessageWidget extends StatelessWidget {
   Widget _buildMessageContent(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        return Container(
-          constraints: BoxConstraints(
-            maxWidth: constraints.maxWidth,
-          ),
-          padding: EdgeInsets.only(right: message.isMe ? 8.w : 0, left: message.isMe ? 0 : 8.w),
-          child: Column(
-            crossAxisAlignment: message.isMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
+        return IntrinsicWidth(
+          child: Container(
+            constraints: BoxConstraints(
+              maxWidth: constraints.maxWidth,
+            ),
+            padding: EdgeInsets.only(right: message.isMe ? 8.w : 0, left: message.isMe ? 0 : 8.w),
+            child: Column(
+              crossAxisAlignment: message.isMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
               if (isGroupMessage && !isSameSenderAsNext && !message.isMe) ...[
                 Text(
                   message.sender.displayName,
@@ -87,7 +88,8 @@ class MessageWidget extends StatelessWidget {
                 SizedBox(height: 4.h),
                 ReactionsRow(message: message, onReactionTap: onReactionTap, context: context),
               ],
-            ],
+              ],
+            ),
           ),
         );
       },


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Replaces the outer Container in _buildMessageContent with an IntrinsicWidth widget to better handle dynamic message sizing within chat bubbles.

Before
<img width="837" height="1355" alt="image" src="https://github.com/user-attachments/assets/d6afa998-f5a0-495f-81ac-6bae6304a026" />

After
<img width="837" height="1354" alt="image" src="https://github.com/user-attachments/assets/0c32100c-0048-4cde-952b-c109460044bd" />


<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes
