### PR TITLE
Test/clipboard tests improvements

### DIFF
--- a/lib/ui/chat/chat_info/chat_info_screen.dart
+++ b/lib/ui/chat/chat_info/chat_info_screen.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
-
 import 'package:whitenoise/config/extensions/toast_extension.dart';
 import 'package:whitenoise/config/providers/active_account_provider.dart';
 import 'package:whitenoise/config/providers/chat_search_provider.dart';
@@ -21,6 +19,7 @@ import 'package:whitenoise/ui/chat/widgets/chat_contact_avatar.dart';
 import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/app_theme.dart';
 import 'package:whitenoise/ui/core/ui/wn_button.dart';
+import 'package:whitenoise/utils/clipboard_utils.dart';
 import 'package:whitenoise/utils/string_extensions.dart';
 
 part 'dm_chat_info.dart';

--- a/lib/ui/chat/chat_info/dm_chat_info.dart
+++ b/lib/ui/chat/chat_info/dm_chat_info.dart
@@ -109,12 +109,12 @@ class _DMChatInfoState extends ConsumerState<DMChatInfo> {
 
   void _copyToClipboard() {
     final npub = otherUserNpub ?? '';
-    if (npub.isEmpty) {
-      ref.showErrorToast('No public key to copy');
-      return;
-    }
-    Clipboard.setData(ClipboardData(text: npub));
-    ref.showSuccessToast('Public Key copied.');
+    ClipboardUtils.copyWithToast(
+      ref: ref,
+      textToCopy: npub,
+      successMessage: 'Public Key copied.',
+      noTextMessage: 'No public key to copy',
+    );
   }
 
   void _openAddToGroup() {

--- a/lib/ui/chat/chat_info/widgets/group_member_bottom_sheet.dart
+++ b/lib/ui/chat/chat_info/widgets/group_member_bottom_sheet.dart
@@ -1,6 +1,5 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -17,6 +16,7 @@ import 'package:whitenoise/ui/core/themes/src/extensions.dart';
 import 'package:whitenoise/ui/core/ui/wn_bottom_sheet.dart';
 import 'package:whitenoise/ui/core/ui/wn_button.dart';
 import 'package:whitenoise/ui/core/ui/wn_dialog.dart';
+import 'package:whitenoise/utils/clipboard_utils.dart';
 import 'package:whitenoise/utils/string_extensions.dart';
 
 import 'member_action_buttons.dart';
@@ -48,12 +48,12 @@ class _GroupMemberBottomSheetState extends ConsumerState<GroupMemberBottomSheet>
 
   void _copyToClipboard() {
     final npub = widget.member.publicKey;
-    if (npub.isEmpty) {
-      ref.showErrorToast('No public key to copy');
-      return;
-    }
-    Clipboard.setData(ClipboardData(text: npub));
-    ref.showSuccessToast('Public Key copied.');
+    ClipboardUtils.copyWithToast(
+      ref: ref,
+      textToCopy: npub,
+      successMessage: 'Public Key copied.',
+      noTextMessage: 'No public key to copy',
+    );
   }
 
   void _openAddToGroup() {

--- a/lib/ui/contact_list/widgets/user_profile.dart
+++ b/lib/ui/contact_list/widgets/user_profile.dart
@@ -28,7 +28,7 @@ class UserProfile extends StatelessWidget {
     ClipboardUtils.copyWithToast(
       ref: ref,
       textToCopy: pubkey,
-      message: 'Public Key copied.',
+      successMessage: 'Public Key copied.',
     );
   }
 

--- a/lib/ui/settings/nostr_keys/nostr_keys_screen.dart
+++ b/lib/ui/settings/nostr_keys/nostr_keys_screen.dart
@@ -6,12 +6,12 @@ import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 import 'package:supa_carbon_icons/supa_carbon_icons.dart';
 
-import 'package:whitenoise/config/extensions/toast_extension.dart';
 import 'package:whitenoise/config/providers/nostr_keys_provider.dart';
 import 'package:whitenoise/shared/custom_icon_button.dart';
 import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
 import 'package:whitenoise/ui/core/ui/wn_text_form_field.dart';
+import 'package:whitenoise/utils/clipboard_utils.dart';
 
 class NostrKeysScreen extends ConsumerStatefulWidget {
   const NostrKeysScreen({super.key});
@@ -37,17 +37,21 @@ class _NostrKeysScreenState extends ConsumerState<NostrKeysScreen> {
 
   void _copyPublicKey() {
     final npub = ref.read(nostrKeysProvider).npub;
-    if (npub != null) {
-      Clipboard.setData(ClipboardData(text: npub));
-      ref.showSuccessToast('Public key copied to clipboard');
-    }
+    ClipboardUtils.copyWithToast(
+      ref: ref,
+      textToCopy: npub,
+      successMessage: 'Public key copied to clipboard',
+    );
   }
 
   void _copyPrivateKey() {
     final nsec = ref.read(nostrKeysProvider).nsec;
     if (nsec != null) {
-      Clipboard.setData(ClipboardData(text: nsec));
-      ref.showSuccessToast('Private key copied to clipboard');
+      ClipboardUtils.copyWithToast(
+        ref: ref,
+        textToCopy: nsec,
+        successMessage: 'Private key copied to clipboard',
+      );
     }
   }
 

--- a/lib/ui/settings/profile/share_profile_screen.dart
+++ b/lib/ui/settings/profile/share_profile_screen.dart
@@ -8,12 +8,12 @@ import 'package:qr_flutter/qr_flutter.dart';
 import 'package:whitenoise/config/extensions/toast_extension.dart';
 import 'package:whitenoise/config/providers/active_account_provider.dart';
 import 'package:whitenoise/config/providers/profile_provider.dart';
-import 'package:whitenoise/config/providers/toast_message_provider.dart';
 import 'package:whitenoise/routing/routes.dart';
 import 'package:whitenoise/ui/chat/widgets/chat_contact_avatar.dart';
 import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/app_theme.dart';
 import 'package:whitenoise/ui/core/ui/wn_button.dart';
+import 'package:whitenoise/utils/clipboard_utils.dart';
 import 'package:whitenoise/utils/string_extensions.dart';
 
 class ShareProfileScreen extends ConsumerStatefulWidget {
@@ -46,12 +46,11 @@ class _ShareProfileScreenState extends ConsumerState<ShareProfileScreen> {
   }
 
   void _copyToClipboard(BuildContext context, String text) {
-    Clipboard.setData(ClipboardData(text: text));
-    ref
-        .read(toastMessageProvider.notifier)
-        .showSuccess(
-          'Public Key copied.',
-        );
+    ClipboardUtils.copyWithToast(
+      ref: ref,
+      textToCopy: text,
+      successMessage: 'Public Key copied.',
+    );
   }
 
   @override

--- a/lib/ui/settings/wallet/wallet_screen.dart
+++ b/lib/ui/settings/wallet/wallet_screen.dart
@@ -1,15 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
-import 'package:whitenoise/config/extensions/toast_extension.dart';
 import 'package:whitenoise/shared/custom_icon_button.dart';
 import 'package:whitenoise/shared/info_box.dart';
 import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
 import 'package:whitenoise/ui/core/ui/wn_app_bar.dart';
 import 'package:whitenoise/ui/core/ui/wn_text_field.dart';
+import 'package:whitenoise/utils/clipboard_utils.dart';
 
 class WalletScreen extends ConsumerStatefulWidget {
   const WalletScreen({super.key});
@@ -78,13 +77,10 @@ class _WalletScreenState extends ConsumerState<WalletScreen> {
                             CustomIconButton(
                               iconPath: AssetsPaths.icCopy,
                               onTap: () {
-                                Clipboard.setData(
-                                  ClipboardData(
-                                    text: _connectionSecretController.text,
-                                  ),
-                                );
-                                ref.showSuccessToast(
-                                  'Connection secret copied to clipboard',
+                                ClipboardUtils.copyWithToast(
+                                  ref: ref,
+                                  textToCopy: _connectionSecretController.text,
+                                  successMessage: 'Connection secret copied to clipboard',
                                 );
                               },
                             ),

--- a/lib/utils/clipboard_utils.dart
+++ b/lib/utils/clipboard_utils.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:whitenoise/config/providers/toast_message_provider.dart';
-import 'package:whitenoise/config/states/toast_state.dart';
+import 'package:whitenoise/config/extensions/toast_extension.dart';
 
 /// Utility class for clipboard operations with toast notifications
 class ClipboardUtils {
@@ -12,19 +11,32 @@ class ClipboardUtils {
   ///
   /// [ref] - WidgetRef for accessing providers
   /// [textToCopy] - The text to copy to clipboard
-  /// [message] - Optional custom message to show (defaults to "Copied to clipboard")
-  static void copyWithToast({
+  /// [successMessage] - Optional custom message to show (defaults to "Copied to clipboard")
+  /// [noTextMessage] - Optional custom error message to show when there is no text to copy (defaults to "Nothing to copy")
+  /// [errorMessage] - Optional custom error message to show when clipboard operation fails (defaults to "Failed to copy to clipboard")
+  static Future<void> copyWithToast({
     required WidgetRef ref,
-    required String textToCopy,
-    String? message,
-  }) {
-    Clipboard.setData(ClipboardData(text: textToCopy));
-    ref
-        .read(toastMessageProvider.notifier)
-        .showRawToast(
-          message: message ?? 'Copied to clipboard',
-          type: ToastType.success,
-          autoDismiss: true,
-        );
+    String? textToCopy,
+    String? successMessage,
+    String? noTextMessage,
+    String? errorMessage,
+  }) async {
+    if (textToCopy == null || textToCopy.isEmpty) {
+      ref.showErrorToast(noTextMessage ?? 'Nothing to copy');
+      return;
+    }
+
+    try {
+      await Clipboard.setData(ClipboardData(text: textToCopy));
+      ref.showSuccessToast(
+        successMessage ?? 'Copied to clipboard',
+        autoDismiss: true,
+      );
+    } catch (e) {
+      ref.showErrorToast(
+        errorMessage ?? 'Failed to copy to clipboard',
+        autoDismiss: true,
+      );
+    }
   }
 }

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -1,58 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:whitenoise/config/providers/toast_message_provider.dart';
-import 'package:whitenoise/config/states/toast_state.dart';
-
-/// Mock toast provider that doesn't create timers during tests
-class MockToastNotifier extends ToastMessageNotifier {
-  @override
-  void showRawToast({
-    required String message,
-    required ToastType type,
-    int? durationMs,
-    bool? autoDismiss,
-    bool? showBelowAppBar,
-  }) {
-  }
-}
-
-/// Mocks clipboard for tests
-Map<String, dynamic> setupClipboardMock(WidgetTester tester) {
-  final clipboardData = <String, dynamic>{};
-  
-  tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-    SystemChannels.platform,
-    (MethodCall methodCall) async {
-      if (methodCall.method == 'Clipboard.setData') {
-        clipboardData['text'] = methodCall.arguments['text'];
-      }
-      return null;
-    },
-  );
-  
-  return clipboardData;
-}
 
 /// Creates test widget with common providers overridden
-Widget createTestWidget(
-  Widget child, {
-  List<Override>? additionalOverrides
-}) {
-  final overrides = [
-    toastMessageProvider.overrideWith(() => MockToastNotifier()),
-    if (additionalOverrides != null) ...additionalOverrides,
-  ];
-
+Widget createTestWidget(Widget child, {List<Override>? overrides}) {
   return ProviderScope(
-    overrides: overrides,
+    overrides: overrides ?? [],
     child: ScreenUtilInit(
       designSize: const Size(375, 812),
-      builder: (context, _) => MaterialApp(
-        home: Scaffold(body: child),
-      ),
+      builder:
+          (context, _) => MaterialApp(
+            home: Scaffold(body: child),
+          ),
     ),
   );
 }

--- a/test/ui/contact_list/share_invite_bottom_sheet_test.dart
+++ b/test/ui/contact_list/share_invite_bottom_sheet_test.dart
@@ -20,77 +20,87 @@ void main() {
     );
 
     testWidgets('displays user name', (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget(
-        SingleChildScrollView(
-          child: ShareInviteBottomSheet(contacts: [testContact]),
+      await tester.pumpWidget(
+        createTestWidget(
+          SingleChildScrollView(
+            child: ShareInviteBottomSheet(contacts: [testContact]),
+          ),
         ),
-      ));
-      
+      );
+
       expect(find.text('Satoshi Nakamoto'), findsOneWidget);
     });
 
     testWidgets('displays nip05', (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget(
-        SingleChildScrollView(
-          child: ShareInviteBottomSheet(contacts: [testContact]),
+      await tester.pumpWidget(
+        createTestWidget(
+          SingleChildScrollView(
+            child: ShareInviteBottomSheet(contacts: [testContact]),
+          ),
         ),
-      ));
-      
+      );
+
       expect(find.text('satoshi@nakamoto.com'), findsOneWidget);
     });
 
     testWidgets('displays formatted pubkey', (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget(
-        SingleChildScrollView(
-          child: ShareInviteBottomSheet(contacts: [testContact]),
+      await tester.pumpWidget(
+        createTestWidget(
+          SingleChildScrollView(
+            child: ShareInviteBottomSheet(contacts: [testContact]),
+          ),
         ),
-      ));
-      
-      expect(find.text(
-        'abc12 3def4 56789 01234 56789 01234 56789 01234 56789 01234 56789 01234 56789 0'
-      ), findsOneWidget);
+      );
+
+      expect(
+        find.text(
+          'abc12 3def4 56789 01234 56789 01234 56789 01234 56789 01234 56789 01234 56789 0',
+        ),
+        findsOneWidget,
+      );
     });
 
-    testWidgets('allows copying npub to clipboard', (WidgetTester tester) async {
-      final clipboardData = setupClipboardMock(tester);
-
-      await tester.pumpWidget(createTestWidget(
-        SingleChildScrollView(
-          child: ShareInviteBottomSheet(contacts: [testContact]),
+    testWidgets('shows copy button', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        createTestWidget(
+          SingleChildScrollView(
+            child: ShareInviteBottomSheet(contacts: [testContact]),
+          ),
         ),
-      ));
+      );
 
       final copyButton = find.byIcon(CarbonIcons.copy);
       expect(copyButton, findsOneWidget);
-      
-      await tester.tap(copyButton);
-    
-      expect(clipboardData['text'], equals(
-        'abc123def456789012345678901234567890123456789012345678901234567890'
-      ));
     });
 
     testWidgets('displays invite callout', (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget(
-        SingleChildScrollView(
-          child: ShareInviteBottomSheet(contacts: [testContact]),
+      await tester.pumpWidget(
+        createTestWidget(
+          SingleChildScrollView(
+            child: ShareInviteBottomSheet(contacts: [testContact]),
+          ),
         ),
-      ));
-      
+      );
+
       expect(find.text('Invite to White Noise'), findsOneWidget);
-      expect(find.textContaining(
-        "Satoshi Nakamoto isn't on White Noise yet. Share the download link to start a secure chat."
-      ), findsOneWidget);
+      expect(
+        find.textContaining(
+          "Satoshi Nakamoto isn't on White Noise yet. Share the download link to start a secure chat.",
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('displays share button', (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget(
-        SingleChildScrollView(
-          child: ShareInviteBottomSheet(contacts: [testContact]),
+      await tester.pumpWidget(
+        createTestWidget(
+          SingleChildScrollView(
+            child: ShareInviteBottomSheet(contacts: [testContact]),
+          ),
         ),
-      ));
-      
+      );
+
       expect(find.text('Share'), findsOneWidget);
     });
   });
-} 
+}

--- a/test/ui/contact_list/start_chat_bottom_sheet_test.dart
+++ b/test/ui/contact_list/start_chat_bottom_sheet_test.dart
@@ -26,97 +26,108 @@ void main() {
     const testPubkey = 'abc123def456789012345678901234567890123456789012345678901234567890';
 
     testWidgets('displays user name', (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget(
-        const StartChatBottomSheet(
-          name: testName,
-          nip05: testNip05,
-          imagePath: testImagePath,
-          pubkey: testPubkey,
+      await tester.pumpWidget(
+        createTestWidget(
+          const StartChatBottomSheet(
+            name: testName,
+            nip05: testNip05,
+            imagePath: testImagePath,
+            pubkey: testPubkey,
+          ),
         ),
-      ));
-      
+      );
+
       expect(find.text('Satoshi Nakamoto'), findsOneWidget);
     });
 
     testWidgets('displays nip05', (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget(
-        const StartChatBottomSheet(
-          name: testName,
-          nip05: testNip05,
-          imagePath: testImagePath,
-          pubkey: testPubkey,
+      await tester.pumpWidget(
+        createTestWidget(
+          const StartChatBottomSheet(
+            name: testName,
+            nip05: testNip05,
+            imagePath: testImagePath,
+            pubkey: testPubkey,
+          ),
         ),
-      ));
-      
+      );
+
       expect(find.text('satoshi@nakamoto.com'), findsOneWidget);
     });
 
     testWidgets('displays formatted pubkey', (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget(
-        const StartChatBottomSheet(
-          name: testName,
-          nip05: testNip05,
-          imagePath: testImagePath,
-          pubkey: testPubkey,
+      await tester.pumpWidget(
+        createTestWidget(
+          const StartChatBottomSheet(
+            name: testName,
+            nip05: testNip05,
+            imagePath: testImagePath,
+            pubkey: testPubkey,
+          ),
         ),
-      ));
-      
-      expect(find.text(
-        'abc12 3def4 56789 01234 56789 01234 56789 01234 56789 01234 56789 01234 56789 0'
-      ), findsOneWidget);
+      );
+
+      expect(
+        find.text(
+          'abc12 3def4 56789 01234 56789 01234 56789 01234 56789 01234 56789 01234 56789 0',
+        ),
+        findsOneWidget,
+      );
     });
 
-    testWidgets('allows copying npub to clipboard', (WidgetTester tester) async {
-      final clipboardData = setupClipboardMock(tester);
-
-      await tester.pumpWidget(createTestWidget(
-        const StartChatBottomSheet(
-          name: testName,
-          nip05: testNip05,
-          pubkey: testPubkey,
+    testWidgets('shows copy button', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        createTestWidget(
+          const StartChatBottomSheet(
+            name: testName,
+            nip05: testNip05,
+            pubkey: testPubkey,
+          ),
         ),
-      ));
+      );
 
       final copyButton = find.byIcon(CarbonIcons.copy);
       expect(copyButton, findsOneWidget);
-      
+
       await tester.tap(copyButton);
-    
-      expect(clipboardData['text'], equals(
-        'abc123def456789012345678901234567890123456789012345678901234567890'
-      ));
     });
 
     testWidgets('displays add contact button', (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget(
-        const StartChatBottomSheet(
-          name: testName,
-          nip05: testNip05,
-          pubkey: testPubkey,
+      await tester.pumpWidget(
+        createTestWidget(
+          const StartChatBottomSheet(
+            name: testName,
+            nip05: testNip05,
+            pubkey: testPubkey,
+          ),
         ),
-      ));
+      );
       expect(find.text('Add Contact'), findsOneWidget);
     });
 
-     testWidgets('displays add to group button', (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget(
-        const StartChatBottomSheet(
-          name: testName,
-          nip05: testNip05,
-          pubkey: testPubkey,
+    testWidgets('displays add to group button', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        createTestWidget(
+          const StartChatBottomSheet(
+            name: testName,
+            nip05: testNip05,
+            pubkey: testPubkey,
+          ),
         ),
-      ));
+      );
       expect(find.text('Add to Group'), findsOneWidget);
     });
 
     testWidgets('displays start chat button', (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget(
-        const StartChatBottomSheet(
-          name: testName,
-          nip05: testNip05,
-          pubkey: testPubkey,
+      await tester.pumpWidget(
+        createTestWidget(
+          const StartChatBottomSheet(
+            name: testName,
+            nip05: testNip05,
+            pubkey: testPubkey,
+          ),
         ),
-      ));
+      );
       expect(find.text('Start Chat'), findsOneWidget);
     });
 
@@ -129,20 +140,22 @@ void main() {
           imagePath: testImagePath,
         );
 
-        await tester.pumpWidget(createTestWidget(
-          const StartChatBottomSheet(
-            name: testName,
-            nip05: testNip05,
-            pubkey: testPubkey,
+        await tester.pumpWidget(
+          createTestWidget(
+            const StartChatBottomSheet(
+              name: testName,
+              nip05: testNip05,
+              pubkey: testPubkey,
+            ),
+            overrides: [
+              contactsProvider.overrideWith(() => MockContactsNotifier([existingContact])),
+            ],
           ),
-          additionalOverrides: [
-            contactsProvider.overrideWith(() => MockContactsNotifier([existingContact])),
-          ],
-        ));
-        
+        );
+
         expect(find.text('Remove Contact'), findsOneWidget);
         expect(find.text('Add Contact'), findsNothing);
       });
     });
   });
-} 
+}

--- a/test/ui/contact_list/widgets/user_profile_test.dart
+++ b/test/ui/contact_list/widgets/user_profile_test.dart
@@ -34,17 +34,18 @@ class UserProfileTestWrapper extends ConsumerWidget {
 
 void main() {
   group('UserProfile Widget Tests', () {
-    
     testWidgets('displays user name correctly', (WidgetTester tester) async {
       const userName = 'John Doe';
       const pubkey = 'abc123def456789012345678901234567890123456789012345678901234567890';
 
-      await tester.pumpWidget(createTestWidget(
-        const UserProfileTestWrapper(
-          name: userName,
-          pubkey: pubkey,
+      await tester.pumpWidget(
+        createTestWidget(
+          const UserProfileTestWrapper(
+            name: userName,
+            pubkey: pubkey,
+          ),
         ),
-      ));
+      );
 
       expect(find.text(userName), findsOneWidget);
     });
@@ -54,13 +55,15 @@ void main() {
       const nip05 = 'john@example.com';
       const pubkey = 'abc123def456789012345678901234567890123456789012345678901234567890';
 
-      await tester.pumpWidget(createTestWidget(
-        const UserProfileTestWrapper(
-          name: userName,
-          nip05: nip05,
-          pubkey: pubkey,
+      await tester.pumpWidget(
+        createTestWidget(
+          const UserProfileTestWrapper(
+            name: userName,
+            nip05: nip05,
+            pubkey: pubkey,
+          ),
         ),
-      ));
+      );
 
       expect(find.text(nip05), findsOneWidget);
     });
@@ -68,37 +71,36 @@ void main() {
     testWidgets('displays formatted public key', (WidgetTester tester) async {
       const userName = 'John Doe';
       const pubkey = 'abc123def456789012345678901234567890123456789012345678901234567890';
-      const expectedFormattedKey = 'abc12 3def4 56789 01234 56789 01234 56789 01234 56789 01234 56789 01234 56789 0';
+      const expectedFormattedKey =
+          'abc12 3def4 56789 01234 56789 01234 56789 01234 56789 01234 56789 01234 56789 0';
 
-      await tester.pumpWidget(createTestWidget(
-        const UserProfileTestWrapper(
-          name: userName,
-          pubkey: pubkey,
+      await tester.pumpWidget(
+        createTestWidget(
+          const UserProfileTestWrapper(
+            name: userName,
+            pubkey: pubkey,
+          ),
         ),
-      ));
+      );
 
       expect(find.text(expectedFormattedKey), findsOneWidget);
     });
 
-    testWidgets('copies pubkey to clipboard', (WidgetTester tester) async {
+    testWidgets('shows copy button', (WidgetTester tester) async {
       const userName = 'John Doe';
       const pubkey = 'abc123def456789012345678901234567890123456789012345678901234567890';
 
-      // Set up clipboard mocking
-      final clipboardData = setupClipboardMock(tester);
-
-      await tester.pumpWidget(createTestWidget(
-        const UserProfileTestWrapper(
-          name: userName,
-          pubkey: pubkey,
+      await tester.pumpWidget(
+        createTestWidget(
+          const UserProfileTestWrapper(
+            name: userName,
+            pubkey: pubkey,
+          ),
         ),
-      ));
+      );
 
       final copyButton = find.byIcon(CarbonIcons.copy);
       expect(copyButton, findsOneWidget);
-      
-      await tester.tap(copyButton);
-      expect(clipboardData['text'], equals(pubkey));
     });
   });
-} 
+}


### PR DESCRIPTION
## Description
In this PR #376  thad solved #279 @codeswot gave me feedback about testing 🫶 , but that PR was merged before I fixed it 🙈 ... so I'm applying the feedback from that PR here

 I tried to apply it here by stop testing called to clipboard set data. Instead, I improved the tests for the clipboard utils by testing  the toast state, handling error case and null case. Then, I removed the previous clipboard tests from widgets. 

Also, replaced same use of clipboard copy with of clipboard utils in multiple screens . This way, the error cases while copying in clipboard are handled almost everywhere (there are a couple of copies that still don't cause they don't use toast to show feedback)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [X] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes
