### PR TITLE
Fix network screen scroll

### DIFF
--- a/lib/ui/settings/network/network_screen.dart
+++ b/lib/ui/settings/network/network_screen.dart
@@ -109,12 +109,10 @@ class _NetworkScreenState extends ConsumerState<NetworkScreen> {
       ),
       child: GestureDetector(
         onPanStart: (details) {
-          if (details.globalPosition.dy < 300) {
-            setState(() {
-              _isPulling = true;
-              _pullDistance = 0.0;
-            });
-          }
+          setState(() {
+            _isPulling = true;
+            _pullDistance = 0.0;
+          });
         },
         onPanUpdate: (details) {
           if (_isPulling) {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Previously, the pull-to-refresh action could only be initiated by a drag gesture starting in the top 300 pixels of the screen. This felt restrictive and unintuitive.

This update removes that positional constraint, allowing the user to pull down from anywhere on the screen to refresh the relay statuses.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes
