### PR TITLE
Fix #433 / Remove .capitalizeFirst from chat header widget

### DIFF
--- a/lib/ui/chat/widgets/chat_header_widget.dart
+++ b/lib/ui/chat/widgets/chat_header_widget.dart
@@ -169,7 +169,7 @@ class _DirectMessageHeaderState extends ConsumerState<DirectMessageHeader> {
               ),
               Gap(12.h),
               Text(
-                otherUser.displayName.capitalizeFirst,
+                otherUser.displayName,
                 style: TextStyle(
                   fontSize: 18.sp,
                   fontWeight: FontWeight.w600,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Now it shows the actual display name.
<img width="900" height="632" alt="image" src="https://github.com/user-attachments/assets/4ae3a602-4d12-4e2c-87df-fe21d84c2474" />

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes

Fixes #433 
