### PR TITLE
447 currently active account should be at the top of the accounts list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed blurry splash screen icon on both iOS and Android.
 - Fixed absence of border on some contact avatars
+- Fixed active profile sorting (active profile comes first in account switcher).
 
 ### Security
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -79,20 +79,20 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
 
 SPEC CHECKSUMS:
-  audio_session: 19e9480dbdd4e5f6c4543826b2e8b0e4ab6145fe
-  emoji_picker_flutter: 8e50ec5caac456a23a78637e02c6293ea0ac8771
+  audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
+  emoji_picker_flutter: ece213fc274bdddefb77d502d33080dc54e616cc
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
-  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
-  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  just_audio: a42c63806f16995daf5b219ae1d679deb76e6a79
-  mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  rust_lib_whitenoise: 69ef24b69b2aba78a7ebabc09a504b5a39177d21
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
+  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
+  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
+  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  rust_lib_whitenoise: 22de658398f8e36a1a396d35b6b6547a0732e6bb
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
 
 PODFILE CHECKSUM: 4305caec6b40dde0ae97be1573c53de1882a07e5
 

--- a/lib/ui/settings/profile/switch_profile_bottom_sheet.dart
+++ b/lib/ui/settings/profile/switch_profile_bottom_sheet.dart
@@ -83,12 +83,12 @@ class _SwitchProfileBottomSheetState extends ConsumerState<SwitchProfileBottomSh
   @override
   void initState() {
     super.initState();
+    _loadActiveAccountHex();
+    _precomputeProfileHexes();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (widget.showSuccessToast) {
         ref.showRawSuccessToast('Signed out. Choose different profile.');
       }
-      _loadActiveAccountHex();
-      _precomputeProfileHexes();
     });
   }
 

--- a/lib/ui/settings/profile/switch_profile_bottom_sheet.dart
+++ b/lib/ui/settings/profile/switch_profile_bottom_sheet.dart
@@ -57,6 +57,28 @@ class SwitchProfileBottomSheet extends ConsumerStatefulWidget {
 class _SwitchProfileBottomSheetState extends ConsumerState<SwitchProfileBottomSheet> {
   String? _activeAccountHex;
   bool _isConnectProfileSheetOpen = false;
+  // Cache for converting any npub profile key to hex for quick sync comparisons
+  final Map<String, String> _pubkeyToHex = {};
+
+  /// Precompute and cache hex versions of all provided profile keys
+  Future<void> _precomputeProfileHexes() async {
+    for (final p in widget.profiles) {
+      final original = p.publicKey;
+      if (_pubkeyToHex.containsKey(original)) continue;
+      try {
+        if (original.startsWith('npub1')) {
+          final hex = await hexPubkeyFromNpub(npub: original);
+          _pubkeyToHex[original] = hex;
+        } else {
+          _pubkeyToHex[original] = original;
+        }
+      } catch (_) {
+        // Fallback to original if conversion fails
+        _pubkeyToHex[original] = original;
+      }
+    }
+    if (mounted) setState(() {});
+  }
 
   @override
   void initState() {
@@ -66,6 +88,7 @@ class _SwitchProfileBottomSheetState extends ConsumerState<SwitchProfileBottomSh
         ref.showRawSuccessToast('Signed out. Choose different profile.');
       }
       _loadActiveAccountHex();
+      _precomputeProfileHexes();
     });
   }
 
@@ -121,18 +144,12 @@ class _SwitchProfileBottomSheetState extends ConsumerState<SwitchProfileBottomSh
 
     // Sort profiles: active account first, then others
     final sortedProfiles = [...widget.profiles];
-    if (activeAccountPubkey != null) {
+    if (activeAccountPubkey != null && _activeAccountHex != null) {
       sortedProfiles.sort((a, b) {
-        // Use cached _activeAccountHex for sorting if available
-        final aIsActive =
-            _activeAccountHex != null &&
-            (a.publicKey == _activeAccountHex ||
-                a.publicKey.startsWith('npub1')); // Will be resolved async
-        final bIsActive =
-            _activeAccountHex != null &&
-            (b.publicKey == _activeAccountHex ||
-                b.publicKey.startsWith('npub1')); // Will be resolved async
-
+        final aHex = _pubkeyToHex[a.publicKey] ?? a.publicKey;
+        final bHex = _pubkeyToHex[b.publicKey] ?? b.publicKey;
+        final aIsActive = aHex == _activeAccountHex;
+        final bIsActive = bHex == _activeAccountHex;
         if (aIsActive && !bIsActive) return -1;
         if (!aIsActive && bIsActive) return 1;
         return 0;

--- a/lib/ui/settings/profile/switch_profile_bottom_sheet.dart
+++ b/lib/ui/settings/profile/switch_profile_bottom_sheet.dart
@@ -62,19 +62,19 @@ class _SwitchProfileBottomSheetState extends ConsumerState<SwitchProfileBottomSh
 
   /// Precompute and cache hex versions of all provided profile keys
   Future<void> _precomputeProfileHexes() async {
-    for (final p in widget.profiles) {
-      final original = p.publicKey;
-      if (_pubkeyToHex.containsKey(original)) continue;
+    for (final profile in widget.profiles) {
+      final originalPubKey = profile.publicKey;
+      if (_pubkeyToHex.containsKey(originalPubKey)) continue;
       try {
-        if (original.startsWith('npub1')) {
-          final hex = await hexPubkeyFromNpub(npub: original);
-          _pubkeyToHex[original] = hex;
+        if (originalPubKey.startsWith('npub1')) {
+          final hex = await hexPubkeyFromNpub(npub: originalPubKey);
+          _pubkeyToHex[originalPubKey] = hex;
         } else {
-          _pubkeyToHex[original] = original;
+          _pubkeyToHex[originalPubKey] = originalPubKey;
         }
       } catch (_) {
         // Fallback to original if conversion fails
-        _pubkeyToHex[original] = original;
+        _pubkeyToHex[originalPubKey] = originalPubKey;
       }
     }
     if (mounted) setState(() {});


### PR DESCRIPTION
## Description

Fixes #447 

## Type of Change

- Fixes issue where the currently active account is not put at the top of the accounts list in the account switcher bottom sheet.

## Benefit

- UX improvement

## File(s) changed

- lib/ui/settings/profile/switch_profile_bottom_sheet.dart

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [x] Updated the `CHANGELOG.md` file with your changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account switcher now reliably shows the active profile first.

* **Performance**
  * Improved profile ordering performance for faster, smoother account switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->