### PR TITLE
chore(justfile): add rust-logs recipe to see rust logs of running app

### DIFF
--- a/justfile
+++ b/justfile
@@ -187,3 +187,51 @@ build-apk:
     scripts/build_android.sh
     just precommit
     flutter build apk --split-per-abi --release
+
+# ==============================================================================
+# LOGS
+# ==============================================================================
+
+# Tail the latest Rust log file produced by the app.
+# Usage:
+#   just rust-logs                # follow in real time (tail -f)
+#   just rust-logs 500            # print last 500 lines and exit
+# Works on macOS simulator and macOS app (container). Falls back to ~/Documents.
+rust-logs lines='':
+    @set -euo pipefail; \
+    BUNDLE_ID=org.parres.whitenoise; \
+    LINES='{{lines}}'; \
+    if [ -z "$LINES" ]; then \
+      echo "🔎 Locating latest Rust log and following in real time..."; \
+    else \
+      echo "🔎 Locating latest Rust log (last ${LINES} lines)..."; \
+    fi; \
+    CANDIDATES=""; \
+    if command -v xcrun >/dev/null 2>&1; then \
+      APP_CONTAINER="$(xcrun simctl get_app_container booted "$BUNDLE_ID" data 2>/dev/null || true)"; \
+      if [ -n "$APP_CONTAINER" ] && [ -d "$APP_CONTAINER" ]; then \
+        CANDIDATES="$CANDIDATES $APP_CONTAINER/Documents/whitenoise/logs/dev"; \
+      fi; \
+    fi; \
+    CANDIDATES="$CANDIDATES $HOME/Library/Containers/$BUNDLE_ID/Data/Documents/whitenoise/logs/dev $HOME/Documents/whitenoise/logs/dev"; \
+    latest=""; latest_mtime=0; \
+    for d in $CANDIDATES; do \
+      if [ -d "$d" ]; then \
+        for f in "$d"/*; do \
+          [ -f "$f" ] || continue; \
+          m=$(stat -f "%m" "$f" 2>/dev/null || echo 0); \
+          if [ "$m" -gt "$latest_mtime" ]; then latest_mtime="$m"; latest="$f"; fi; \
+        done; \
+      fi; \
+    done; \
+    if [ -n "$latest" ]; then \
+      echo "Latest log file: $latest"; \
+      if [ -z "$LINES" ]; then \
+        tail -f "$latest"; \
+      else \
+        tail -n "$LINES" "$latest"; \
+      fi; \
+    else \
+      echo "❌ No log files found. Ensure the app has run and produced logs."; \
+      exit 1; \
+    fi


### PR DESCRIPTION
Adds rust-logs recipe to see logs on MacOS using an iPhone simulator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a rust-logs Just recipe to access the most recent Rust log file.
  - Supports real-time following when no line count is provided, or printing the last N lines.
  - Automatically locates the latest log across macOS simulator/container paths and common user directories.
  - Outputs the selected log path before streaming and reports a clear error if no log is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->