### PR TITLE
feat: enhance message navigation with PopScope for search deactivation

### DIFF
--- a/lib/ui/chat/chat_screen.dart
+++ b/lib/ui/chat/chat_screen.dart
@@ -206,173 +206,180 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       }
     });
 
-    return Scaffold(
-      resizeToAvoidBottomInset: true,
-      body: NotificationListener<ScrollNotification>(
-        onNotification: (scrollInfo) {
-          if (scrollInfo is ScrollUpdateNotification) {
-            final currentFocus = FocusManager.instance.primaryFocus;
-            if (currentFocus != null && currentFocus.hasFocus) {
-              final currentOffset = scrollInfo.metrics.pixels;
-              final scrollDelta = currentOffset - _lastScrollOffset;
-              if (scrollDelta < -20) currentFocus.unfocus();
-              _lastScrollOffset = currentOffset;
+    return PopScope(
+      onPopInvokedWithResult: (_, _) {
+        if (searchState.isSearchActive) {
+          searchNotifier.deactivateSearch();
+        }
+      },
+      child: Scaffold(
+        resizeToAvoidBottomInset: true,
+        body: NotificationListener<ScrollNotification>(
+          onNotification: (scrollInfo) {
+            if (scrollInfo is ScrollUpdateNotification) {
+              final currentFocus = FocusManager.instance.primaryFocus;
+              if (currentFocus != null && currentFocus.hasFocus) {
+                final currentOffset = scrollInfo.metrics.pixels;
+                final scrollDelta = currentOffset - _lastScrollOffset;
+                if (scrollDelta < -20) currentFocus.unfocus();
+                _lastScrollOffset = currentOffset;
+              }
             }
-          }
-          return false;
-        },
-        child: GestureDetector(
-          onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
-          behavior: HitTestBehavior.translucent,
-          child: Column(
-            children: [
-              if (searchState.isSearchActive)
-                ChatSearchWidget(
-                  groupId: widget.groupId,
-                  onClose: searchNotifier.deactivateSearch,
-                ),
-              Expanded(
-                child: Stack(
-                  children: [
-                    CustomScrollView(
-                      controller: _scrollController,
-                      slivers: [
-                        if (!searchState.isSearchActive)
-                          WnAppBar.sliver(
-                            floating: true,
-                            pinned: true,
-                            title: FutureBuilder(
-                              future: _dmChatDataFuture,
-                              builder: (context, snapshot) {
-                                if (snapshot.connectionState == ConnectionState.waiting) {
-                                  return const ContactInfo.loading();
+            return false;
+          },
+          child: GestureDetector(
+            onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+            behavior: HitTestBehavior.translucent,
+            child: Column(
+              children: [
+                if (searchState.isSearchActive)
+                  ChatSearchWidget(
+                    groupId: widget.groupId,
+                    onClose: searchNotifier.deactivateSearch,
+                  ),
+                Expanded(
+                  child: Stack(
+                    children: [
+                      CustomScrollView(
+                        controller: _scrollController,
+                        slivers: [
+                          if (!searchState.isSearchActive)
+                            WnAppBar.sliver(
+                              floating: true,
+                              pinned: true,
+                              title: FutureBuilder(
+                                future: _dmChatDataFuture,
+                                builder: (context, snapshot) {
+                                  if (snapshot.connectionState == ConnectionState.waiting) {
+                                    return const ContactInfo.loading();
+                                  }
+                                  final otherUser = snapshot.data;
+                                  return ContactInfo(
+                                    title:
+                                        groupData.groupType == GroupType.directMessage
+                                            ? otherUser?.displayName ?? ''
+                                            : groupData.name,
+                                    image:
+                                        groupData.groupType == GroupType.directMessage
+                                            ? otherUser?.displayImage ?? ''
+                                            : '',
+                                    onTap: () => context.push('/chats/${widget.groupId}/info'),
+                                  );
+                                },
+                              ),
+                            ),
+                          SliverPadding(
+                            padding: EdgeInsets.symmetric(
+                              horizontal: 8.w,
+                              vertical: 8.h,
+                            ).copyWith(bottom: 120.h),
+                            sliver: SliverList.builder(
+                              itemCount: messages.length + 1,
+                              itemBuilder: (context, index) {
+                                if (index == 0) {
+                                  return ChatContactHeader(groupData: groupData);
                                 }
-                                final otherUser = snapshot.data;
-                                return ContactInfo(
-                                  title:
-                                      groupData.groupType == GroupType.directMessage
-                                          ? otherUser?.displayName ?? ''
-                                          : groupData.name,
-                                  image:
-                                      groupData.groupType == GroupType.directMessage
-                                          ? otherUser?.displayImage ?? ''
-                                          : '',
-                                  onTap: () => context.push('/chats/${widget.groupId}/info'),
+                                final message = messages[index - 1];
+                                return SwipeToReplyWidget(
+                                  message: message,
+                                  onReply:
+                                      () => chatNotifier.handleReply(
+                                        message,
+                                        groupId: widget.groupId,
+                                      ),
+                                  onTap:
+                                      () => ChatDialogService.showReactionDialog(
+                                        context: context,
+                                        ref: ref,
+                                        message: message,
+                                        messageIndex: index,
+                                      ),
+                                  child: Hero(
+                                    tag: message.id,
+                                    child: MessageWidget(
+                                          message: message,
+                                          isGroupMessage: groupData.groupType == GroupType.group,
+                                          isSameSenderAsPrevious: chatNotifier.isSameSender(
+                                            index,
+                                            groupId: widget.groupId,
+                                          ),
+                                          isSameSenderAsNext: chatNotifier.isSameSender(
+                                            index - 1,
+                                            groupId: widget.groupId,
+                                          ),
+                                          searchMatch:
+                                              searchState.matches.isNotEmpty
+                                                  ? _getMessageSearchMatch(
+                                                    searchState.matches,
+                                                    message.id,
+                                                  )
+                                                  : null,
+                                          isActiveSearchMatch:
+                                              searchNotifier.currentMatch?.messageId == message.id,
+                                          currentActiveMatch:
+                                              searchNotifier.currentMatch?.messageId == message.id
+                                                  ? searchNotifier.currentMatch
+                                                  : null,
+                                          isSearchActive: searchState.isSearchActive,
+                                          onReactionTap: (reaction) {
+                                            chatNotifier.updateMessageReaction(
+                                              message: message,
+                                              reaction: reaction,
+                                            );
+                                          },
+                                          onReplyTap: (messageId) {
+                                            _scrollToMessage(messageId);
+                                          },
+                                        )
+                                        .animate()
+                                        .fadeIn(duration: const Duration(milliseconds: 200))
+                                        .slide(
+                                          begin: const Offset(0, 0.1),
+                                          duration: const Duration(milliseconds: 200),
+                                        ),
+                                  ),
                                 );
                               },
                             ),
                           ),
-                        SliverPadding(
-                          padding: EdgeInsets.symmetric(
-                            horizontal: 8.w,
-                            vertical: 8.h,
-                          ).copyWith(bottom: 120.h),
-                          sliver: SliverList.builder(
-                            itemCount: messages.length + 1,
-                            itemBuilder: (context, index) {
-                              if (index == 0) {
-                                return ChatContactHeader(groupData: groupData);
-                              }
-                              final message = messages[index - 1];
-                              return SwipeToReplyWidget(
-                                message: message,
-                                onReply:
-                                    () => chatNotifier.handleReply(
-                                      message,
-                                      groupId: widget.groupId,
-                                    ),
-                                onTap:
-                                    () => ChatDialogService.showReactionDialog(
-                                      context: context,
-                                      ref: ref,
-                                      message: message,
-                                      messageIndex: index,
-                                    ),
-                                child: Hero(
-                                  tag: message.id,
-                                  child: MessageWidget(
-                                        message: message,
-                                        isGroupMessage: groupData.groupType == GroupType.group,
-                                        isSameSenderAsPrevious: chatNotifier.isSameSender(
-                                          index,
-                                          groupId: widget.groupId,
-                                        ),
-                                        isSameSenderAsNext: chatNotifier.isSameSender(
-                                          index - 1,
-                                          groupId: widget.groupId,
-                                        ),
-                                        searchMatch:
-                                            searchState.matches.isNotEmpty
-                                                ? _getMessageSearchMatch(
-                                                  searchState.matches,
-                                                  message.id,
-                                                )
-                                                : null,
-                                        isActiveSearchMatch:
-                                            searchNotifier.currentMatch?.messageId == message.id,
-                                        currentActiveMatch:
-                                            searchNotifier.currentMatch?.messageId == message.id
-                                                ? searchNotifier.currentMatch
-                                                : null,
-                                        isSearchActive: searchState.isSearchActive,
-                                        onReactionTap: (reaction) {
-                                          chatNotifier.updateMessageReaction(
-                                            message: message,
-                                            reaction: reaction,
-                                          );
-                                        },
-                                        onReplyTap: (messageId) {
-                                          _scrollToMessage(messageId);
-                                        },
-                                      )
-                                      .animate()
-                                      .fadeIn(duration: const Duration(milliseconds: 200))
-                                      .slide(
-                                        begin: const Offset(0, 0.1),
-                                        duration: const Duration(milliseconds: 200),
-                                      ),
-                                ),
-                              );
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-                    if (messages.isNotEmpty)
-                      Positioned(
-                        bottom: 0,
-                        left: 0,
-                        right: 0,
-                        height: 20.h,
-                        child: const WnBottomFade().animate().fadeIn(),
+                        ],
                       ),
-                  ],
+                      if (messages.isNotEmpty)
+                        Positioned(
+                          bottom: 0,
+                          left: 0,
+                          right: 0,
+                          height: 20.h,
+                          child: const WnBottomFade().animate().fadeIn(),
+                        ),
+                    ],
+                  ),
                 ),
-              ),
-              if (!searchState.isSearchActive)
-                ChatInput(
-                  groupId: widget.groupId,
-                  onSend: (message, isEditing) async {
-                    final chatState = ref.read(chatProvider);
-                    final replyingTo = chatState.replyingTo[widget.groupId];
-                    if (replyingTo != null) {
-                      await chatNotifier.sendReplyMessage(
-                        groupId: widget.groupId,
-                        replyToMessageId: replyingTo.id,
-                        message: message,
-                        onMessageSent: _handleScrollToBottom,
-                      );
-                    } else {
-                      await chatNotifier.sendMessage(
-                        groupId: widget.groupId,
-                        message: message,
-                        isEditing: isEditing,
-                        onMessageSent: _handleScrollToBottom,
-                      );
-                    }
-                  },
-                ),
-            ],
+                if (!searchState.isSearchActive)
+                  ChatInput(
+                    groupId: widget.groupId,
+                    onSend: (message, isEditing) async {
+                      final chatState = ref.read(chatProvider);
+                      final replyingTo = chatState.replyingTo[widget.groupId];
+                      if (replyingTo != null) {
+                        await chatNotifier.sendReplyMessage(
+                          groupId: widget.groupId,
+                          replyToMessageId: replyingTo.id,
+                          message: message,
+                          onMessageSent: _handleScrollToBottom,
+                        );
+                      } else {
+                        await chatNotifier.sendMessage(
+                          groupId: widget.groupId,
+                          message: message,
+                          isEditing: isEditing,
+                          onMessageSent: _handleScrollToBottom,
+                        );
+                      }
+                    },
+                  ),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
Auto-close chat search on 
  navigation

  Adds automatic search bar
  dismissal when users navigate
  away from chat screens via back
  button or swipe gestures.
  Previously, the search bar would
  remain open when returning to a
  chat, creating an inconsistent
  UX.

  Changes:
  - Wrapped ChatScreen with
  PopScope to intercept navigation
  attempts
  - Added onPopInvokedWithResult
  callback to deactivate search
  before allowing navigation
  - Maintains existing search
  functionality while improving
  navigation flow

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)
