### PR TITLE
Sensitive clipboard handling for Android private key copying

### DIFF
--- a/android/app/src/main/kotlin/com/example/whitenoise/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/whitenoise/MainActivity.kt
@@ -1,5 +1,45 @@
 package org.parres.whitenoise
 
+import android.content.ClipData
+import android.content.ClipDescription
+import android.content.ClipboardManager
+import android.os.PersistableBundle
+import android.os.Build
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity: FlutterActivity() {
+    private val CHANNEL = "clipboard_sensitive"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
+            if (call.method == "setSensitive") {
+                val text = call.argument<String>("text")
+                if (text != null) {
+                    setSensitiveClipboard(text)
+                    result.success(null)
+                } else {
+                    result.error("NO_TEXT", "Text was null", null)
+                }
+            } else {
+                result.notImplemented()
+            }
+        }
+    }
+
+    private fun setSensitiveClipboard(text: String) {
+        val clipboard = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+        val clip = ClipData.newPlainText("label", text)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU || Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val extras = PersistableBundle()
+            extras.putBoolean(ClipDescription.EXTRA_IS_SENSITIVE, true)
+            clip.description.extras = extras
+        }
+
+        clipboard.setPrimaryClip(clip)
+    }
+}

--- a/lib/ui/settings/profile_keys/profile_keys_screen.dart
+++ b/lib/ui/settings/profile_keys/profile_keys_screen.dart
@@ -44,10 +44,10 @@ class _ProfileKeysScreenState extends ConsumerState<ProfileKeysScreen> {
     );
   }
 
-  void _copyPrivateKey() {
+  void _copyPrivateKey() async {
     final nsec = ref.read(nostrKeysProvider).nsec;
     if (nsec != null) {
-      ClipboardUtils.copyWithToast(
+      await ClipboardUtils.copySensitiveWithToast(
         ref: ref,
         textToCopy: nsec,
         successMessage: 'Private key copied to clipboard',


### PR DESCRIPTION
## Description

Fixes #503

Added a method channel to let Android 13+ know that what the user is copying is sensitive, thereby masking it in the copy preview. 

## Benefit

Added security.

## Notes

New method in ClipboardUtils now called ```copySensitiveWithToast``` to be used in place of ```copyWithToast``` when copying sensitive data like nsec.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [x] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)
