### PR TITLE
feat: make it possible to navigate to group details screen.

### DIFF
--- a/lib/ui/chat/widgets/contact_info.dart
+++ b/lib/ui/chat/widgets/contact_info.dart
@@ -49,7 +49,7 @@ class ContactInfo extends StatelessWidget {
       );
     }
 
-    return Row(
+    final content = Row(
       children: [
         WnAvatar(
           imageUrl: image!,
@@ -68,5 +68,14 @@ class ContactInfo extends StatelessWidget {
         ),
       ],
     );
+
+    if (onTap != null) {
+      return GestureDetector(
+        onTap: onTap,
+        child: content,
+      );
+    }
+
+    return content;
   }
 }


### PR DESCRIPTION
## Description

Fixes #554 where tapping on the group name in the appbar doesn't navigate to the group details screen

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)
