### PR TITLE
Fix/pubkey formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed get user logic, to show metadata when searching a new npub
 - Fixes profile edition with outdated metadata
+- Fixes pubkeys formatting and pubkeys comparisons in different format
 
 ### Security
 

--- a/lib/config/providers/active_pubkey_provider.dart
+++ b/lib/config/providers/active_pubkey_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:whitenoise/domain/services/account_secure_storage_service.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 
 // Default FlutterSecureStorage instance
 const _defaultSecureStorage = FlutterSecureStorage(
@@ -12,11 +13,17 @@ const _defaultSecureStorage = FlutterSecureStorage(
   ),
 );
 
+PubkeyFormatter _defaultPubkeyFormatter({String? pubkey}) => PubkeyFormatter(pubkey: pubkey);
+
 class ActivePubkeyNotifier extends Notifier<String?> {
   final FlutterSecureStorage storage;
+  final PubkeyFormatter Function({String? pubkey}) pubkeyFormatter;
 
-  ActivePubkeyNotifier({FlutterSecureStorage? storage})
-    : storage = storage ?? _defaultSecureStorage;
+  ActivePubkeyNotifier({
+    FlutterSecureStorage? storage,
+    PubkeyFormatter Function({String? pubkey})? pubkeyFormatter,
+  }) : storage = storage ?? _defaultSecureStorage,
+       pubkeyFormatter = pubkeyFormatter ?? _defaultPubkeyFormatter;
 
   @override
   String? build() {
@@ -26,13 +33,18 @@ class ActivePubkeyNotifier extends Notifier<String?> {
 
   Future<void> loadActivePubkey() async {
     final pubkey = await AccountSecureStorageService.getActivePubkey(storage: storage);
-    state = pubkey?.trim();
+    final hexPubkey = pubkeyFormatter(pubkey: pubkey).toHex();
+    state = hexPubkey;
   }
 
   Future<void> setActivePubkey(String pubkey) async {
-    final trimmedPubkey = pubkey.trim();
-    await AccountSecureStorageService.setActivePubkey(trimmedPubkey, storage: storage);
-    state = trimmedPubkey;
+    final hexPubkey = pubkeyFormatter(pubkey: pubkey).toHex();
+    if (hexPubkey == null) {
+      await clearActivePubkey();
+    } else {
+      await AccountSecureStorageService.setActivePubkey(hexPubkey, storage: storage);
+    }
+    state = hexPubkey;
   }
 
   Future<void> clearActivePubkey() async {

--- a/lib/config/providers/auth_provider.dart
+++ b/lib/config/providers/auth_provider.dart
@@ -9,7 +9,7 @@ import 'package:whitenoise/config/states/auth_state.dart';
 import 'package:whitenoise/src/rust/api.dart' show createWhitenoiseConfig, initializeWhitenoise;
 import 'package:whitenoise/src/rust/api/accounts.dart';
 import 'package:whitenoise/src/rust/api/error.dart' show ApiError;
-import 'package:whitenoise/src/rust/api/utils.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 
 /// Auth Provider
 ///
@@ -291,16 +291,10 @@ class AuthNotifier extends Notifier<AuthState> {
         // Check if there are other accounts available
         final remainingAccounts = await getAccounts();
         // Normalize pubkeys to hex then filter
-        final activeHex =
-            activeAccount.pubkey.startsWith('npub')
-                ? hexPubkeyFromNpub(npub: activeAccount.pubkey)
-                : activeAccount.pubkey.toLowerCase();
+        final activeHex = PubkeyFormatter(pubkey: activeAccount.pubkey).toHex();
         final otherAccounts = <Account>[];
         for (final account in remainingAccounts) {
-          final keyHex =
-              account.pubkey.startsWith('npub')
-                  ? hexPubkeyFromNpub(npub: account.pubkey)
-                  : account.pubkey.toLowerCase();
+          final keyHex = PubkeyFormatter(pubkey: account.pubkey).toHex();
           if (keyHex != activeHex) otherAccounts.add(account);
         }
         if (otherAccounts.isNotEmpty) {

--- a/lib/config/providers/auth_provider.dart
+++ b/lib/config/providers/auth_provider.dart
@@ -13,7 +13,7 @@ import 'package:whitenoise/utils/pubkey_formatter.dart';
 
 /// Auth Provider
 ///
-/// This provider manages authentication using the new PublicKey-based API.
+/// This provider manages authentication.
 class AuthNotifier extends Notifier<AuthState> {
   final _logger = Logger('AuthNotifier');
 

--- a/lib/config/providers/chat_provider.dart
+++ b/lib/config/providers/chat_provider.dart
@@ -12,6 +12,7 @@ import 'package:whitenoise/src/rust/api/error.dart' show ApiError;
 import 'package:whitenoise/src/rust/api/messages.dart';
 import 'package:whitenoise/src/rust/api/utils.dart';
 import 'package:whitenoise/utils/message_converter.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 
 class ChatNotifier extends Notifier<ChatState> {
   final _logger = Logger('ChatNotifier');
@@ -426,7 +427,12 @@ class ChatNotifier extends Notifier<ChatState> {
     if (gId == null) return false;
     final groupMessages = state.groupMessages[gId] ?? [];
     if (index <= 0 || index >= groupMessages.length) return false;
-    return groupMessages[index].sender.publicKey == groupMessages[index - 1].sender.publicKey;
+    final currentSenderPubkey = groupMessages[index].sender.publicKey;
+    final currentSenderHexPubkey = PubkeyFormatter(pubkey: currentSenderPubkey).toHex() ?? '';
+    final previousSenderPubkey = groupMessages[index - 1].sender.publicKey;
+    final previousSenderHexPubkey = PubkeyFormatter(pubkey: previousSenderPubkey).toHex() ?? '';
+    if (currentSenderHexPubkey.isEmpty || previousSenderHexPubkey.isEmpty) return false;
+    return currentSenderHexPubkey == previousSenderHexPubkey;
   }
 
   bool isNextSameSender(int index, {String? groupId}) {
@@ -434,7 +440,12 @@ class ChatNotifier extends Notifier<ChatState> {
     if (gId == null) return false;
     final groupMessages = state.groupMessages[gId] ?? [];
     if (index < 0 || index >= groupMessages.length - 1) return false;
-    return groupMessages[index].sender.publicKey == groupMessages[index + 1].sender.publicKey;
+    final currentSenderPubkey = groupMessages[index].sender.publicKey;
+    final currentSenderHexPubkey = PubkeyFormatter(pubkey: currentSenderPubkey).toHex() ?? '';
+    final nextSenderPubkey = groupMessages[index + 1].sender.publicKey;
+    final nextSenderHexPubkey = PubkeyFormatter(pubkey: nextSenderPubkey).toHex() ?? '';
+    if (currentSenderHexPubkey.isEmpty || nextSenderHexPubkey.isEmpty) return false;
+    return currentSenderHexPubkey == nextSenderHexPubkey;
   }
 
   /// Get unread message count for a group

--- a/lib/config/providers/follows_provider.dart
+++ b/lib/config/providers/follows_provider.dart
@@ -7,6 +7,7 @@ import 'package:whitenoise/config/providers/auth_provider.dart';
 import 'package:whitenoise/src/rust/api/accounts.dart' as accounts_api;
 import 'package:whitenoise/src/rust/api/users.dart';
 import 'package:whitenoise/utils/error_handling.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 import 'package:whitenoise/utils/user_utils.dart';
 
 class FollowsState {
@@ -197,7 +198,9 @@ class FollowsNotifier extends Notifier<FollowsState> {
   }
 
   bool isFollowing(String pubkey) {
-    return state.follows.any((user) => user.pubkey == pubkey);
+    final hexPubkey = PubkeyFormatter(pubkey: pubkey).toHex();
+    if (hexPubkey == null) return false;
+    return state.follows.any((user) => PubkeyFormatter(pubkey: user.pubkey).toHex() == hexPubkey);
   }
 
   List<User> get allFollows => state.follows;

--- a/lib/config/providers/group_provider.dart
+++ b/lib/config/providers/group_provider.dart
@@ -217,13 +217,11 @@ class GroupsNotifier extends Notifier<GroupsState> {
       final filteredMemberHexs =
           memberPublicKeyHexs.where((hex) => hex.trim() != creatorPubkeyHex).toList();
 
-      // Use hex strings directly instead of converting to PublicKey objects
       final filteredMemberPubkeys = filteredMemberHexs.map((hexKey) => hexKey.trim()).toList();
       _logger.info(
         'GroupsProvider: Members pubkeys loaded (excluding creator) - ${filteredMemberPubkeys.length}',
       );
 
-      // Use hex strings directly instead of converting to PublicKey objects
       final resolvedAdminPublicKeys =
           adminPublicKeyHexs.toSet().map((hexKey) => hexKey.trim()).toList();
       final combinedAdminKeys = {activePubkey, ...resolvedAdminPublicKeys}.toList();

--- a/lib/config/providers/metadata_cache_provider.dart
+++ b/lib/config/providers/metadata_cache_provider.dart
@@ -6,7 +6,7 @@ import 'package:logging/logging.dart';
 import 'package:whitenoise/config/providers/active_pubkey_provider.dart';
 import 'package:whitenoise/domain/models/contact_model.dart';
 import 'package:whitenoise/src/rust/api/users.dart' as wn_users_api;
-import 'package:whitenoise/src/rust/api/utils.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 import 'package:whitenoise/utils/public_key_validation_extension.dart';
 
 /// Cached metadata with basic expiration
@@ -68,7 +68,7 @@ class MetadataCacheNotifier extends Notifier<MetadataCacheState> {
   /// Convert hex to npub safely
   Future<String> _safeHexToNpub(String hexPubkey) async {
     try {
-      return npubFromHexPubkey(hexPubkey: hexPubkey);
+      return PubkeyFormatter(pubkey: hexPubkey).toNpub() ?? '';
     } catch (e) {
       _logger.warning('Failed to convert hex to npub for $hexPubkey: $e');
       return hexPubkey;
@@ -78,7 +78,7 @@ class MetadataCacheNotifier extends Notifier<MetadataCacheState> {
   /// Convert npub to hex safely
   Future<String> _safeNpubToHex(String npub) async {
     try {
-      return hexPubkeyFromNpub(npub: npub);
+      return PubkeyFormatter(pubkey: npub).toHex() ?? '';
     } catch (e) {
       _logger.warning('Failed to convert npub to hex for $npub: $e');
       return npub;

--- a/lib/config/providers/nostr_keys_provider.dart
+++ b/lib/config/providers/nostr_keys_provider.dart
@@ -4,7 +4,7 @@ import 'package:whitenoise/config/providers/active_pubkey_provider.dart';
 import 'package:whitenoise/config/providers/auth_provider.dart';
 import 'package:whitenoise/config/states/nostr_keys_state.dart';
 import 'package:whitenoise/src/rust/api/accounts.dart';
-import 'package:whitenoise/utils/public_key_validation_extension.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 
 final _logger = Logger('NostrKeysNotifier');
 
@@ -42,8 +42,7 @@ class NostrKeysNotifier extends Notifier<NostrKeysState> {
 
       _logger.info('NostrKeysNotifier: Loading keys for account: $activePubkey');
 
-      // Load npub and nsec directly from hex pubkey string
-      final activeNpub = activePubkey.toNpub();
+      final activeNpub = PubkeyFormatter(pubkey: activePubkey).toNpub() ?? '';
       final activeNsec = await exportAccountNsec(pubkey: activePubkey);
 
       state = state.copyWith(

--- a/lib/domain/models/contact_model.dart
+++ b/lib/domain/models/contact_model.dart
@@ -72,7 +72,10 @@ class ContactModel {
   bool operator ==(covariant ContactModel other) {
     if (identical(this, other)) return true;
 
-    return other.publicKey == publicKey &&
+    final hexNpub = PubkeyFormatter(pubkey: publicKey).toHex();
+    final otherHexNpub = PubkeyFormatter(pubkey: other.publicKey).toHex();
+
+    return hexNpub == otherHexNpub &&
         other.imagePath == imagePath &&
         other.displayName == displayName &&
         other.about == about &&

--- a/lib/domain/models/contact_model.dart
+++ b/lib/domain/models/contact_model.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:whitenoise/src/rust/api/metadata.dart' show FlutterMetadata;
-import 'package:whitenoise/utils/public_key_validation_extension.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 
 class ContactModel {
   final String publicKey;
@@ -33,7 +33,7 @@ class ContactModel {
     final nip05 = _sanitizeString(metadata?.nip05);
     final lud16 = _sanitizeString(metadata?.lud16);
     final picture = _sanitizeUrl(metadata?.picture);
-    final npub = pubkey.toNpub() ?? '';
+    final npub = PubkeyFormatter(pubkey: pubkey).toNpub() ?? '';
 
     return ContactModel(
       displayName: displayName.isNotEmpty ? displayName : 'Unknown User',

--- a/lib/domain/services/dm_chat_service.dart
+++ b/lib/domain/services/dm_chat_service.dart
@@ -4,8 +4,7 @@ import 'package:whitenoise/config/providers/group_provider.dart';
 import 'package:whitenoise/domain/models/contact_model.dart';
 import 'package:whitenoise/domain/models/dm_chat_data.dart';
 import 'package:whitenoise/src/rust/api/users.dart' as wn_users_api;
-import 'package:whitenoise/src/rust/api/utils.dart';
-import 'package:whitenoise/utils/public_key_validation_extension.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 
 class DMChatService {
   static Future<DMChatData?> getDMChatData(String groupId, WidgetRef ref) async {
@@ -13,10 +12,7 @@ class DMChatService {
       final activePubkey = ref.read(activePubkeyProvider) ?? '';
       if (activePubkey.isEmpty) return null;
 
-      final currentUserNpub = npubFromHexPubkey(
-        hexPubkey: activePubkey,
-      );
-
+      final currentUserNpub = PubkeyFormatter(pubkey: activePubkey).toNpub();
       final otherMember = ref
           .read(groupsProvider.notifier)
           .getOtherGroupMember(
@@ -27,10 +23,7 @@ class DMChatService {
       if (otherMember != null) {
         final user = await wn_users_api.getUser(pubkey: otherMember.publicKey);
         final otherMemberPubkey = otherMember.publicKey;
-        String otherMemberNpubPubkey = otherMemberPubkey;
-        if (otherMemberPubkey.isValidHexPublicKey) {
-          otherMemberNpubPubkey = npubFromHexPubkey(hexPubkey: otherMemberPubkey);
-        }
+        final otherMemberNpubPubkey = PubkeyFormatter(pubkey: otherMemberPubkey).toNpub() ?? '';
         final contactModel = ContactModel.fromMetadata(
           pubkey: otherMemberNpubPubkey,
           metadata: user.metadata,

--- a/lib/domain/services/dm_chat_service.dart
+++ b/lib/domain/services/dm_chat_service.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:whitenoise/config/providers/active_pubkey_provider.dart';
 import 'package:whitenoise/config/providers/group_provider.dart';
 import 'package:whitenoise/domain/models/contact_model.dart';
 import 'package:whitenoise/domain/models/dm_chat_data.dart';
@@ -9,15 +8,10 @@ import 'package:whitenoise/utils/pubkey_formatter.dart';
 class DMChatService {
   static Future<DMChatData?> getDMChatData(String groupId, WidgetRef ref) async {
     try {
-      final activePubkey = ref.read(activePubkeyProvider) ?? '';
-      if (activePubkey.isEmpty) return null;
-
-      final currentUserNpub = PubkeyFormatter(pubkey: activePubkey).toNpub();
       final otherMember = ref
           .read(groupsProvider.notifier)
           .getOtherGroupMember(
             groupId,
-            currentUserNpub,
           );
 
       if (otherMember != null) {

--- a/lib/ui/chat/chat_info/chat_info_screen.dart
+++ b/lib/ui/chat/chat_info/chat_info_screen.dart
@@ -13,7 +13,6 @@ import 'package:whitenoise/domain/models/dm_chat_data.dart';
 import 'package:whitenoise/domain/models/user_model.dart';
 import 'package:whitenoise/domain/services/dm_chat_service.dart';
 import 'package:whitenoise/src/rust/api/groups.dart';
-import 'package:whitenoise/src/rust/api/utils.dart';
 import 'package:whitenoise/ui/chat/chat_info/widgets/group_member_bottom_sheet.dart';
 import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/app_theme.dart';
@@ -21,7 +20,7 @@ import 'package:whitenoise/ui/core/ui/wn_avatar.dart';
 import 'package:whitenoise/ui/core/ui/wn_button.dart';
 import 'package:whitenoise/ui/core/ui/wn_image.dart';
 import 'package:whitenoise/utils/clipboard_utils.dart';
-import 'package:whitenoise/utils/public_key_validation_extension.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 import 'package:whitenoise/utils/string_extensions.dart';
 
 part 'dm_chat_info.dart';

--- a/lib/ui/chat/chat_info/dm_chat_info.dart
+++ b/lib/ui/chat/chat_info/dm_chat_info.dart
@@ -35,12 +35,12 @@ class _DMChatInfoState extends ConsumerState<DMChatInfo> {
   Future<void> _loadContact() async {
     final activePubkey = ref.read(activePubkeyProvider) ?? '';
     if (activePubkey.isNotEmpty) {
-      final currentUserNpub = activePubkey.toNpub();
+      final currentUserNpub = PubkeyFormatter(pubkey: activePubkey).toNpub() ?? '';
       final otherMember = ref
           .read(groupsProvider.notifier)
           .getOtherGroupMember(widget.groupId, currentUserNpub);
       if (otherMember != null && mounted) {
-        otherUserNpub = otherMember.publicKey.toNpub();
+        otherUserNpub = PubkeyFormatter(pubkey: otherMember.publicKey).toNpub() ?? '';
         _checkFollowStatus(otherMember.publicKey);
       }
     }

--- a/lib/ui/chat/chat_info/dm_chat_info.dart
+++ b/lib/ui/chat/chat_info/dm_chat_info.dart
@@ -35,12 +35,9 @@ class _DMChatInfoState extends ConsumerState<DMChatInfo> {
   Future<void> _loadContact() async {
     final activePubkey = ref.read(activePubkeyProvider) ?? '';
     if (activePubkey.isNotEmpty) {
-      final currentUserNpub = PubkeyFormatter(pubkey: activePubkey).toNpub() ?? '';
-      final otherMember = ref
-          .read(groupsProvider.notifier)
-          .getOtherGroupMember(widget.groupId, currentUserNpub);
+      final otherMember = ref.read(groupsProvider.notifier).getOtherGroupMember(widget.groupId);
       if (otherMember != null && mounted) {
-        otherUserNpub = PubkeyFormatter(pubkey: otherMember.publicKey).toNpub() ?? '';
+        otherUserNpub = PubkeyFormatter(pubkey: otherMember.publicKey).toNpub();
         _checkFollowStatus(otherMember.publicKey);
       }
     }

--- a/lib/ui/chat/chat_info/group_chat_info.dart
+++ b/lib/ui/chat/chat_info/group_chat_info.dart
@@ -30,9 +30,7 @@ class _GroupChatInfoState extends ConsumerState<GroupChatInfo> {
     final groupDetails = ref.read(groupsProvider).groupsMap?[widget.groupId];
     if (groupDetails?.nostrGroupId != null) {
       try {
-        final npub = npubFromHexPubkey(
-          hexPubkey: groupDetails!.nostrGroupId,
-        );
+        final npub = PubkeyFormatter(pubkey: groupDetails?.nostrGroupId).toNpub();
         if (mounted) {
           setState(() {
             groupNpub = npub;
@@ -104,7 +102,7 @@ class _GroupChatInfoState extends ConsumerState<GroupChatInfo> {
   Future<void> _loadCurrentUserNpub() async {
     final activeAccount = ref.read(activePubkeyProvider) ?? '';
     if (activeAccount.isNotEmpty) {
-      final currentUserNpub = npubFromHexPubkey(hexPubkey: activeAccount);
+      final currentUserNpub = PubkeyFormatter(pubkey: activeAccount).toNpub();
       if (mounted) {
         setState(() {
           this.currentUserNpub = currentUserNpub;

--- a/lib/ui/chat/chat_info/group_chat_info.dart
+++ b/lib/ui/chat/chat_info/group_chat_info.dart
@@ -56,17 +56,30 @@ class _GroupChatInfoState extends ConsumerState<GroupChatInfo> {
       allMembers.addAll(members);
 
       for (final admin in admins) {
-        if (!members.any((member) => member.publicKey == admin.publicKey)) {
+        if (!members.any((member) {
+          final hexMemberKey = PubkeyFormatter(pubkey: member.publicKey).toHex();
+          final hexAdminKey = PubkeyFormatter(pubkey: admin.publicKey).toHex();
+          return hexMemberKey == hexAdminKey;
+        })) {
           allMembers.add(admin);
         }
       }
 
       // Sort members: admins first (A-Z), then regular members (A-Z), current user last
       allMembers.sort((a, b) {
-        final aIsAdmin = admins.any((admin) => admin.publicKey == a.publicKey);
-        final bIsAdmin = admins.any((admin) => admin.publicKey == b.publicKey);
-        final aIsCurrentUser = currentUserNpub != null && currentUserNpub == a.publicKey;
-        final bIsCurrentUser = currentUserNpub != null && currentUserNpub == b.publicKey;
+        final hexPubkeyA = PubkeyFormatter(pubkey: a.publicKey).toHex();
+        final hexPubkeyB = PubkeyFormatter(pubkey: b.publicKey).toHex();
+        final hexCurrentUserNpub = PubkeyFormatter(pubkey: currentUserNpub).toHex();
+        final aIsAdmin = admins.any((admin) {
+          final hexAdminKey = PubkeyFormatter(pubkey: admin.publicKey).toHex();
+          return hexAdminKey == hexPubkeyA;
+        });
+        final bIsAdmin = admins.any((admin) {
+          final hexAdminKey = PubkeyFormatter(pubkey: admin.publicKey).toHex();
+          return hexAdminKey == hexPubkeyB;
+        });
+        final aIsCurrentUser = currentUserNpub != null && (hexCurrentUserNpub == hexPubkeyA);
+        final bIsCurrentUser = currentUserNpub != null && (hexCurrentUserNpub == hexPubkeyB);
 
         // Current user always goes last
         if (aIsCurrentUser) return 1;
@@ -216,8 +229,15 @@ class _GroupChatInfoState extends ConsumerState<GroupChatInfo> {
   }
 
   Widget _buildMemberListTile(User member, {String? currentUserNpub}) {
-    final isAdmin = groupAdmins.any((admin) => admin.publicKey == member.publicKey);
-    final isCurrentUser = currentUserNpub != null && currentUserNpub == member.publicKey;
+    final isAdmin = groupAdmins.any((admin) {
+      final hexAdminKey = PubkeyFormatter(pubkey: admin.publicKey).toHex();
+      final hexMemberKey = PubkeyFormatter(pubkey: member.publicKey).toHex();
+      return hexAdminKey == hexMemberKey;
+    });
+    final isCurrentUser =
+        currentUserNpub != null &&
+        PubkeyFormatter(pubkey: currentUserNpub).toHex() ==
+            PubkeyFormatter(pubkey: member.publicKey).toHex();
     return ListTile(
       contentPadding: EdgeInsets.symmetric(horizontal: 32.w),
 

--- a/lib/ui/chat/chat_info/widgets/group_member_bottom_sheet.dart
+++ b/lib/ui/chat/chat_info/widgets/group_member_bottom_sheet.dart
@@ -16,7 +16,7 @@ import 'package:whitenoise/ui/core/ui/wn_button.dart';
 import 'package:whitenoise/ui/core/ui/wn_dialog.dart';
 import 'package:whitenoise/ui/core/ui/wn_image.dart';
 import 'package:whitenoise/utils/clipboard_utils.dart';
-import 'package:whitenoise/utils/public_key_validation_extension.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 import 'package:whitenoise/utils/string_extensions.dart';
 
 import 'member_action_buttons.dart';
@@ -67,7 +67,7 @@ class _GroupMemberBottomSheetState extends ConsumerState<GroupMemberBottomSheet>
   void _loadCurrentUserNpub() async {
     final activeAccountPubkey = ref.read(activePubkeyProvider) ?? '';
     if (activeAccountPubkey.isNotEmpty) {
-      currentUserNpub = activeAccountPubkey.toNpub() ?? '';
+      currentUserNpub = PubkeyFormatter(pubkey: activeAccountPubkey).toNpub() ?? '';
       setState(() {});
     }
   }

--- a/lib/ui/chat/chat_info/widgets/member_action_buttons.dart
+++ b/lib/ui/chat/chat_info/widgets/member_action_buttons.dart
@@ -11,6 +11,7 @@ import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
 import 'package:whitenoise/ui/core/ui/wn_button.dart';
 import 'package:whitenoise/ui/core/ui/wn_image.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 
 class SendMessageButton extends ConsumerStatefulWidget {
   const SendMessageButton(this.user, {super.key});
@@ -111,7 +112,12 @@ class _AddToContactButtonState extends ConsumerState<AddToContactButton> {
     final follows = followsState.follows;
 
     return follows.any(
-      (follow) => follow.pubkey.toLowerCase() == widget.user.publicKey.toLowerCase(),
+      (follow) {
+        final hexFollowPubkey = PubkeyFormatter(pubkey: follow.pubkey).toHex();
+        final hexUserPubkey = PubkeyFormatter(pubkey: widget.user.publicKey).toHex();
+        if (hexFollowPubkey == null || hexUserPubkey == null) return false;
+        return hexFollowPubkey == hexUserPubkey;
+      },
     );
   }
 

--- a/lib/ui/chat/invite/chat_invite_screen.dart
+++ b/lib/ui/chat/invite/chat_invite_screen.dart
@@ -7,13 +7,13 @@ import 'package:whitenoise/config/providers/group_provider.dart';
 import 'package:whitenoise/config/providers/toast_message_provider.dart';
 import 'package:whitenoise/config/providers/user_profile_data_provider.dart';
 import 'package:whitenoise/config/providers/welcomes_provider.dart';
-import 'package:whitenoise/src/rust/api/utils.dart';
 import 'package:whitenoise/src/rust/api/welcomes.dart';
 import 'package:whitenoise/ui/chat/widgets/contact_info.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
 import 'package:whitenoise/ui/core/ui/wn_app_bar.dart';
 import 'package:whitenoise/ui/core/ui/wn_avatar.dart';
 import 'package:whitenoise/ui/core/ui/wn_button.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 import 'package:whitenoise/utils/string_extensions.dart';
 
 class ChatInviteScreen extends ConsumerStatefulWidget {
@@ -178,7 +178,7 @@ class GroupInviteHeader extends StatelessWidget {
           ),
           Gap(16.h),
           Text(
-            npubFromHexPubkey(hexPubkey: welcome.nostrGroupId).formatPublicKey(),
+            PubkeyFormatter(pubkey: welcome.nostrGroupId).toNpub()?.formatPublicKey() ?? '',
             textAlign: TextAlign.center,
             style: TextStyle(
               fontSize: 14.sp,
@@ -280,7 +280,7 @@ class DMInviteHeader extends ConsumerWidget {
               ),
               Gap(12.h),
               Text(
-                npubFromHexPubkey(hexPubkey: welcome.welcomer).formatPublicKey(),
+                PubkeyFormatter(pubkey: welcome.welcomer).toNpub()?.formatPublicKey() ?? '',
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 12.sp,

--- a/lib/ui/chat/widgets/chat_header_widget.dart
+++ b/lib/ui/chat/widgets/chat_header_widget.dart
@@ -6,10 +6,10 @@ import 'package:whitenoise/config/providers/group_provider.dart';
 import 'package:whitenoise/domain/models/dm_chat_data.dart';
 import 'package:whitenoise/domain/services/dm_chat_service.dart';
 import 'package:whitenoise/src/rust/api/groups.dart';
-import 'package:whitenoise/src/rust/api/utils.dart';
 import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
 import 'package:whitenoise/ui/core/ui/wn_avatar.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 import 'package:whitenoise/utils/string_extensions.dart';
 
 class ChatContactHeader extends ConsumerWidget {
@@ -56,14 +56,14 @@ class _GroupChatHeaderState extends ConsumerState<GroupChatHeader> {
   @override
   void initState() {
     super.initState();
-    _groupNpub = npubFromHexPubkey(hexPubkey: widget.group.nostrGroupId);
+    _groupNpub = PubkeyFormatter(pubkey: widget.group.nostrGroupId).toNpub();
   }
 
   @override
   void didUpdateWidget(GroupChatHeader oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.group.nostrGroupId != widget.group.nostrGroupId) {
-      _groupNpub = npubFromHexPubkey(hexPubkey: widget.group.nostrGroupId);
+      _groupNpub = PubkeyFormatter(pubkey: widget.group.nostrGroupId).toNpub();
     }
   }
 

--- a/lib/ui/contact_list/group_welcome_invitation_sheet.dart
+++ b/lib/ui/contact_list/group_welcome_invitation_sheet.dart
@@ -6,12 +6,12 @@ import 'package:whitenoise/config/extensions/toast_extension.dart';
 import 'package:whitenoise/config/providers/active_pubkey_provider.dart';
 import 'package:whitenoise/src/rust/api/metadata.dart' show FlutterMetadata;
 import 'package:whitenoise/src/rust/api/users.dart' as wn_users_api;
-import 'package:whitenoise/src/rust/api/utils.dart';
 import 'package:whitenoise/src/rust/api/welcomes.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
 import 'package:whitenoise/ui/core/ui/wn_avatar.dart';
 import 'package:whitenoise/ui/core/ui/wn_bottom_sheet.dart';
 import 'package:whitenoise/ui/core/ui/wn_button.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 import 'package:whitenoise/utils/string_extensions.dart';
 
 class GroupWelcomeInvitationSheet extends StatelessWidget {
@@ -126,7 +126,7 @@ class _GroupMessageInviteState extends ConsumerState<GroupMessageInvite> {
 
   Future<String> _getDisplayablePublicKey() async {
     try {
-      final npub = npubFromHexPubkey(hexPubkey: widget.welcome.nostrGroupId);
+      final npub = PubkeyFormatter(pubkey: widget.welcome.nostrGroupId).toNpub() ?? '';
       return npub;
     } catch (e) {
       return widget.welcome.nostrGroupId.formatPublicKey();
@@ -296,7 +296,7 @@ class _DirectMessageInviteCardState extends ConsumerState<DirectMessageInviteCar
 
   Future<String> _getDisplayablePublicKey() async {
     try {
-      final npub = npubFromHexPubkey(hexPubkey: widget.welcome.welcomer);
+      final npub = PubkeyFormatter(pubkey: widget.welcome.welcomer).toNpub() ?? '';
       return npub;
     } catch (e) {
       return widget.welcome.welcomer.formatPublicKey();

--- a/lib/ui/contact_list/widgets/chat_list_item_tile.dart
+++ b/lib/ui/contact_list/widgets/chat_list_item_tile.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 import 'package:whitenoise/config/providers/group_provider.dart';
-import 'package:whitenoise/config/providers/nostr_keys_provider.dart';
 import 'package:whitenoise/domain/models/chat_list_item.dart';
 import 'package:whitenoise/domain/models/dm_chat_data.dart';
 import 'package:whitenoise/domain/models/message_model.dart';
@@ -50,12 +49,8 @@ class ChatListItemTile extends ConsumerWidget {
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
             // Show loading state with basic info while determining group type
-            final currentUserNpub = ref.watch(nostrKeysProvider).npub ?? '';
             final displayName = groupsNotifier.getGroupDisplayName(group.mlsGroupId) ?? group.name;
-            final displayImage = groupsNotifier.getGroupDisplayImage(
-              group.mlsGroupId,
-              currentUserNpub,
-            );
+            final displayImage = groupsNotifier.getGroupDisplayImage(group.mlsGroupId);
             return _buildChatTileContent(context, displayName, displayImage, group);
           }
 
@@ -89,12 +84,8 @@ class ChatListItemTile extends ConsumerWidget {
           final data = snapshot.data;
           if (data == null) {
             // Fallback to existing logic if no data
-            final currentUserNpub = ref.watch(nostrKeysProvider).npub ?? '';
             final displayName = groupsNotifier.getGroupDisplayName(group.mlsGroupId) ?? group.name;
-            final displayImage = groupsNotifier.getGroupDisplayImage(
-              group.mlsGroupId,
-              currentUserNpub,
-            );
+            final displayImage = groupsNotifier.getGroupDisplayImage(group.mlsGroupId);
             return _buildChatTileContent(context, displayName, displayImage, group);
           }
 
@@ -103,10 +94,8 @@ class ChatListItemTile extends ConsumerWidget {
       );
     }
 
-    // For regular groups, use existing logic
-    final currentUserNpub = ref.watch(nostrKeysProvider).npub ?? '';
     final displayName = groupsNotifier.getGroupDisplayName(group.mlsGroupId) ?? group.name;
-    final displayImage = groupsNotifier.getGroupDisplayImage(group.mlsGroupId, currentUserNpub);
+    final displayImage = groupsNotifier.getGroupDisplayImage(group.mlsGroupId);
 
     return _buildChatTileContent(context, displayName, displayImage, group);
   }

--- a/lib/ui/contact_list/widgets/contact_list_tile.dart
+++ b/lib/ui/contact_list/widgets/contact_list_tile.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
 import 'package:whitenoise/domain/models/contact_model.dart';
-import 'package:whitenoise/src/rust/api/utils.dart';
 import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
 import 'package:whitenoise/ui/core/ui/wn_avatar.dart';
 import 'package:whitenoise/ui/core/ui/wn_image.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 import 'package:whitenoise/utils/string_extensions.dart';
 
 class ContactListTile extends StatelessWidget {
@@ -33,7 +33,7 @@ class ContactListTile extends StatelessWidget {
 
   Future<String> _getNpub(String publicKeyHex) async {
     try {
-      final npub = npubFromHexPubkey(hexPubkey: publicKeyHex);
+      final npub = PubkeyFormatter(pubkey: publicKeyHex).toNpub() ?? '';
       return npub.formatPublicKey();
     } catch (e) {
       // Return the full hex key as fallback

--- a/lib/ui/settings/general_settings_screen.dart
+++ b/lib/ui/settings/general_settings_screen.dart
@@ -15,7 +15,6 @@ import 'package:whitenoise/domain/models/contact_model.dart';
 import 'package:whitenoise/domain/services/draft_message_service.dart';
 import 'package:whitenoise/routing/routes.dart';
 import 'package:whitenoise/src/rust/api/accounts.dart' show Account, getAccounts;
-import 'package:whitenoise/src/rust/api/utils.dart';
 import 'package:whitenoise/ui/contact_list/widgets/contact_list_tile.dart';
 import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
@@ -25,6 +24,7 @@ import 'package:whitenoise/ui/core/ui/wn_dialog.dart';
 import 'package:whitenoise/ui/core/ui/wn_image.dart';
 import 'package:whitenoise/ui/settings/developer/developer_settings_screen.dart';
 import 'package:whitenoise/ui/settings/profile/switch_profile_bottom_sheet.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 import 'package:whitenoise/utils/public_key_validation_extension.dart';
 
 class GeneralSettingsScreen extends ConsumerStatefulWidget {
@@ -152,7 +152,7 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
           // Try to convert npub to hex for matching
           String hexKey = selectedProfile.publicKey;
           if (selectedProfile.publicKey.isValidNpubPublicKey) {
-            hexKey = hexPubkeyFromNpub(npub: selectedProfile.publicKey);
+            hexKey = PubkeyFormatter(pubkey: selectedProfile.publicKey).toHex() ?? '';
           }
 
           selectedAccount = _accounts.where((account) => account.pubkey == hexKey).firstOrNull;

--- a/lib/ui/settings/general_settings_screen.dart
+++ b/lib/ui/settings/general_settings_screen.dart
@@ -157,9 +157,12 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
 
           selectedAccount = _accounts.where((account) => account.pubkey == hexKey).firstOrNull;
         } catch (e) {
-          // If conversion fails, try direct matching as fallback
+          final hexProfilePubKey = PubkeyFormatter(pubkey: selectedProfile.publicKey).toHex();
           selectedAccount =
-              _accounts.where((account) => account.pubkey == selectedProfile.publicKey).firstOrNull;
+              _accounts.where((account) {
+                final hexAccountPubkey = PubkeyFormatter(pubkey: account.pubkey).toHex();
+                return hexAccountPubkey == hexProfilePubKey;
+              }).firstOrNull;
         }
 
         if (selectedAccount != null) {

--- a/lib/ui/settings/profile/share_profile_screen.dart
+++ b/lib/ui/settings/profile/share_profile_screen.dart
@@ -14,7 +14,7 @@ import 'package:whitenoise/ui/core/ui/wn_avatar.dart';
 import 'package:whitenoise/ui/core/ui/wn_button.dart';
 import 'package:whitenoise/ui/core/ui/wn_image.dart';
 import 'package:whitenoise/utils/clipboard_utils.dart';
-import 'package:whitenoise/utils/public_key_validation_extension.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 import 'package:whitenoise/utils/string_extensions.dart';
 
 class ShareProfileScreen extends ConsumerStatefulWidget {
@@ -38,7 +38,7 @@ class _ShareProfileScreenState extends ConsumerState<ShareProfileScreen> {
   Future<void> loadProfile() async {
     try {
       final activeAccountPubkey = ref.read(activePubkeyProvider) ?? '';
-      npub = activeAccountPubkey.toNpub() ?? '';
+      npub = PubkeyFormatter(pubkey: activeAccountPubkey).toNpub() ?? '';
       setState(() {});
     } catch (e) {
       if (!mounted) return;

--- a/lib/ui/settings/profile/switch_profile_bottom_sheet.dart
+++ b/lib/ui/settings/profile/switch_profile_bottom_sheet.dart
@@ -5,12 +5,12 @@ import 'package:gap/gap.dart';
 import 'package:whitenoise/config/extensions/toast_extension.dart';
 import 'package:whitenoise/config/providers/active_pubkey_provider.dart';
 import 'package:whitenoise/domain/models/contact_model.dart';
-import 'package:whitenoise/src/rust/api/utils.dart';
 import 'package:whitenoise/ui/contact_list/widgets/contact_list_tile.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
 import 'package:whitenoise/ui/core/ui/wn_bottom_sheet.dart';
 import 'package:whitenoise/ui/core/ui/wn_button.dart';
 import 'package:whitenoise/ui/settings/profile/connect_profile_bottom_sheet.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
 
 class SwitchProfileBottomSheet extends ConsumerStatefulWidget {
   final List<ContactModel> profiles;
@@ -65,17 +65,9 @@ class _SwitchProfileBottomSheetState extends ConsumerState<SwitchProfileBottomSh
     for (final profile in widget.profiles) {
       final originalPubKey = profile.publicKey;
       if (_pubkeyToHex.containsKey(originalPubKey)) continue;
-      try {
-        if (originalPubKey.startsWith('npub1')) {
-          final hex = hexPubkeyFromNpub(npub: originalPubKey);
-          _pubkeyToHex[originalPubKey] = hex;
-        } else {
-          _pubkeyToHex[originalPubKey] = originalPubKey;
-        }
-      } catch (_) {
-        // Fallback to original if conversion fails
-        _pubkeyToHex[originalPubKey] = originalPubKey;
-      }
+      final hexPubkey = PubkeyFormatter(pubkey: originalPubKey).toHex();
+      if (hexPubkey == null) continue;
+      _pubkeyToHex[originalPubKey] = hexPubkey;
     }
     if (mounted) setState(() {});
   }
@@ -105,12 +97,7 @@ class _SwitchProfileBottomSheetState extends ConsumerState<SwitchProfileBottomSh
     if (_activeAccountHex == null) return false;
 
     try {
-      // Convert profile's npub key to hex for comparison
-      String profileHex = profile.publicKey;
-      if (profile.publicKey.startsWith('npub1')) {
-        profileHex = hexPubkeyFromNpub(npub: profile.publicKey);
-      }
-
+      final String profileHex = PubkeyFormatter(pubkey: profile.publicKey).toHex() ?? '';
       return profileHex == _activeAccountHex;
     } catch (e) {
       // If conversion fails, try direct comparison as fallback

--- a/lib/utils/pubkey_formatter.dart
+++ b/lib/utils/pubkey_formatter.dart
@@ -1,0 +1,54 @@
+import 'package:whitenoise/src/rust/api/utils.dart' as wn_utils_api;
+import 'package:whitenoise/utils/public_key_validation_extension.dart';
+
+class PubkeyFormatter {
+  final String? _pubkey;
+  final String? Function({required String hexPubkey}) _npubFromHexPubkey;
+  final String? Function({required String npub}) _hexPubkeyFromNpub;
+
+  PubkeyFormatter({
+    String? pubkey,
+    String? Function({required String hexPubkey})? npubFromHexPubkey,
+    String? Function({required String npub})? hexPubkeyFromNpub,
+  }) : _pubkey = pubkey,
+       _npubFromHexPubkey = npubFromHexPubkey ?? wn_utils_api.npubFromHexPubkey,
+       _hexPubkeyFromNpub = hexPubkeyFromNpub ?? wn_utils_api.hexPubkeyFromNpub;
+
+  String? toNpub() {
+    if (_pubkey == null) return null;
+    final trimmedPubkey = _pubkey.trim().toLowerCase();
+    final PublicKeyType? pubkeyType = trimmedPubkey.publicKeyType;
+    if (!trimmedPubkey.isValidPublicKey) return null;
+
+    if (pubkeyType == PublicKeyType.npub) {
+      return trimmedPubkey;
+    } else if (pubkeyType == PublicKeyType.hex) {
+      try {
+        final npub = _npubFromHexPubkey(hexPubkey: trimmedPubkey);
+        return npub;
+      } catch (e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  String? toHex() {
+    if (_pubkey == null) return null;
+    final trimmedPubkey = _pubkey.trim().toLowerCase();
+    final PublicKeyType? pubkeyType = trimmedPubkey.publicKeyType;
+    if (!trimmedPubkey.isValidPublicKey) return null;
+
+    if (pubkeyType == PublicKeyType.hex) {
+      return trimmedPubkey;
+    } else if (pubkeyType == PublicKeyType.npub) {
+      try {
+        final hex = _hexPubkeyFromNpub(npub: trimmedPubkey);
+        return hex;
+      } catch (e) {
+        return null;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/utils/public_key_validation_extension.dart
+++ b/lib/utils/public_key_validation_extension.dart
@@ -1,7 +1,5 @@
-import 'package:whitenoise/src/rust/api/utils.dart' show hexPubkeyFromNpub, npubFromHexPubkey;
-
-/// Extension for validating public keys in various formats
-/// Supports both hex format (64 characters) and npub format (bech32)
+// Extension for validating public keys in various formats
+// Supports both hex format (64 characters) and npub format (bech32)
 
 extension PublicKeyValidationExtension on String {
   /// Validates if the string is a valid public key
@@ -43,48 +41,6 @@ extension PublicKeyValidationExtension on String {
   PublicKeyType? get publicKeyType {
     if (isValidHexPublicKey) return PublicKeyType.hex;
     if (isValidNpubPublicKey) return PublicKeyType.npub;
-    return null;
-  }
-
-  /// Converts a hex pubkey to npub format
-  /// If the pubkey is already in npub format, returns the original pubkey
-  /// Returns null if conversion fails
-  String? toNpub() {
-    final trimmedPubkey = trim().toLowerCase();
-    final PublicKeyType? pubkeyType = trimmedPubkey.publicKeyType;
-    if (!trimmedPubkey.isValidPublicKey) return null;
-
-    if (pubkeyType == PublicKeyType.npub) {
-      return trimmedPubkey;
-    } else if (pubkeyType == PublicKeyType.hex) {
-      try {
-        final npub = npubFromHexPubkey(hexPubkey: trimmedPubkey);
-        return npub;
-      } catch (e) {
-        return null;
-      }
-    }
-    return null;
-  }
-
-  /// Converts a npub pubkey to hex format
-  /// If the pubkey is already in hex format, returns the original pubkey
-  /// Returns null if conversion fails
-  String? toHex() {
-    final trimmedPubkey = trim().toLowerCase();
-    final PublicKeyType? pubkeyType = trimmedPubkey.publicKeyType;
-    if (!trimmedPubkey.isValidPublicKey) return null;
-
-    if (pubkeyType == PublicKeyType.hex) {
-      return trimmedPubkey;
-    } else if (pubkeyType == PublicKeyType.npub) {
-      try {
-        final hex = hexPubkeyFromNpub(npub: trimmedPubkey);
-        return hex;
-      } catch (e) {
-        return null;
-      }
-    }
     return null;
   }
 }

--- a/test/config/providers/active_account_provider_test.dart
+++ b/test/config/providers/active_account_provider_test.dart
@@ -70,7 +70,7 @@ class MockWnAccountsApi implements WnAccountsApi {
     if (account == null) {
       throw StateError('Account not found');
     }
-    
+
     return account;
   }
 
@@ -82,18 +82,19 @@ class MockWnAccountsApi implements WnAccountsApi {
       throw Exception('Network error');
     }
 
-    return _metadata[pubkey] ?? const FlutterMetadata(
-      name: '',
-      displayName: '',
-      about: '',
-      picture: '',
-      banner: '',
-      website: '',
-      nip05: '',
-      lud06: '',
-      lud16: '',
-      custom: {},
-    );
+    return _metadata[pubkey] ??
+        const FlutterMetadata(
+          name: '',
+          displayName: '',
+          about: '',
+          picture: '',
+          banner: '',
+          website: '',
+          nip05: '',
+          lud06: '',
+          lud16: '',
+          custom: {},
+        );
   }
 
   @override
@@ -175,6 +176,7 @@ final otherTestMetadata = const FlutterMetadata(
 
 void main() {
   group('ActiveAccountProvider Tests', () {
+    TestWidgetsFlutterBinding.ensureInitialized();
     late ProviderContainer container;
     late MockWnAccountsApi mockAccountsApi;
     late MockWnImageUtils mockImageUtils;
@@ -211,7 +213,6 @@ void main() {
     });
 
     group('account', () {
-
       group('with null active pubkey', () {
         setUp(() {
           container = createContainer();
@@ -308,7 +309,6 @@ void main() {
     });
 
     group('metadata', () {
-
       group('with null active pubkey', () {
         setUp(() {
           container = createContainer();
@@ -380,12 +380,15 @@ void main() {
       group('when active pubkey changes', () {
         setUp(() {
           mockAccountsApi.setAccount('test_pubkey_123', testAccount);
-          mockAccountsApi.setAccount('test_pubkey_456', accounts_api.Account(
-            pubkey: 'test_pubkey_456',
-            lastSyncedAt: DateTime.now(),
-            createdAt: DateTime.now().subtract(const Duration(days: 60)),
-            updatedAt: DateTime.now().subtract(const Duration(hours: 2)),
-          ));
+          mockAccountsApi.setAccount(
+            'test_pubkey_456',
+            accounts_api.Account(
+              pubkey: 'test_pubkey_456',
+              lastSyncedAt: DateTime.now(),
+              createdAt: DateTime.now().subtract(const Duration(days: 60)),
+              updatedAt: DateTime.now().subtract(const Duration(hours: 2)),
+            ),
+          );
           mockAccountsApi.setMetadata('test_pubkey_123', testMetadata);
           mockAccountsApi.setMetadata('test_pubkey_456', otherTestMetadata);
           container = createContainer(activePubkey: 'test_pubkey_123');
@@ -422,7 +425,7 @@ void main() {
 
         test('throws exception for null pubkey', () async {
           final notifier = container.read(activeAccountProvider.notifier);
-          
+
           expect(
             () => notifier.updateMetadata(metadata: newMetadata),
             throwsA(isA<Exception>()),
@@ -437,7 +440,7 @@ void main() {
 
         test('throws exception for empty pubkey', () async {
           final notifier = container.read(activeAccountProvider.notifier);
-          
+
           expect(
             () => notifier.updateMetadata(metadata: newMetadata),
             throwsA(isA<Exception>()),
@@ -501,7 +504,7 @@ void main() {
 
         test('throws exception for null pubkey', () async {
           final notifier = container.read(activeAccountProvider.notifier);
-          
+
           expect(
             () => notifier.uploadProfilePicture(filePath: testFilePath),
             throwsA(isA<Exception>()),
@@ -516,7 +519,7 @@ void main() {
 
         test('throws exception for empty pubkey', () async {
           final notifier = container.read(activeAccountProvider.notifier);
-          
+
           expect(
             () => notifier.uploadProfilePicture(filePath: testFilePath),
             throwsA(isA<Exception>()),
@@ -536,9 +539,9 @@ void main() {
 
         test('returns profile picture URL when upload is successful', () async {
           final notifier = container.read(activeAccountProvider.notifier);
-          
+
           final profilePictureUrl = await notifier.uploadProfilePicture(filePath: testFilePath);
-          
+
           expect(profilePictureUrl, 'https://example.com/profile-pictures/test_pubkey_123.jpg');
         });
       });
@@ -556,7 +559,7 @@ void main() {
 
         test('throws error when upload fails', () async {
           final notifier = container.read(activeAccountProvider.notifier);
-          
+
           expect(
             () => notifier.uploadProfilePicture(filePath: testFilePath),
             throwsA(isA<Exception>()),
@@ -568,7 +571,7 @@ void main() {
         setUp(() {
           final mockImageUtilsForNull = MockWnImageUtils();
           mockImageUtilsForNull.setMimeType(null);
-          
+
           mockAccountsApi.setAccount('test_pubkey_123', testAccount);
           mockAccountsApi.setMetadata('test_pubkey_123', testMetadata);
           container = createContainer(
@@ -580,13 +583,14 @@ void main() {
 
         test('throws error when image type cannot be determined', () async {
           final notifier = container.read(activeAccountProvider.notifier);
-          
+
           expect(
             () => notifier.uploadProfilePicture(filePath: testFilePath),
-            throwsA(predicate((e) => 
-              e is Exception && 
-              e.toString().contains('Could not determine image type')
-            )),
+            throwsA(
+              predicate(
+                (e) => e is Exception && e.toString().contains('Could not determine image type'),
+              ),
+            ),
           );
         });
       });

--- a/test/config/providers/active_pubkey_provider_test.mocks.dart
+++ b/test/config/providers/active_pubkey_provider_test.mocks.dart
@@ -8,6 +8,7 @@ import 'dart:async' as _i4;
 import 'package:flutter/foundation.dart' as _i3;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:whitenoise/utils/pubkey_formatter.dart' as _i5;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -315,4 +316,13 @@ class MockFlutterSecureStorage extends _i1.Mock
             returnValue: _i4.Future<bool?>.value(),
           )
           as _i4.Future<bool?>);
+}
+
+/// A class which mocks [PubkeyFormatter].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockPubkeyFormatter extends _i1.Mock implements _i5.PubkeyFormatter {
+  MockPubkeyFormatter() {
+    _i1.throwOnMissingStub(this);
+  }
 }

--- a/test/config/providers/group_provider_test.dart
+++ b/test/config/providers/group_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:whitenoise/src/rust/api/groups.dart';
 
 void main() {
   group('GroupsProvider Tests', () {
+    TestWidgetsFlutterBinding.ensureInitialized();
     late ProviderContainer container;
 
     // Test data
@@ -113,7 +114,9 @@ void main() {
           nip05: 'test@example.com',
           publicKey: 'test_pubkey',
         );
-        final testGroupMembers = <String, List<User>>{'group1': [testUser]};
+        final testGroupMembers = <String, List<User>>{
+          'group1': [testUser],
+        };
 
         notifier.state = notifier.state.copyWith(groupMembers: testGroupMembers);
 
@@ -130,7 +133,9 @@ void main() {
           nip05: 'admin@example.com',
           publicKey: 'admin_pubkey',
         );
-        final testGroupAdmins = <String, List<User>>{'group1': [testUser]};
+        final testGroupAdmins = <String, List<User>>{
+          'group1': [testUser],
+        };
 
         notifier.state = notifier.state.copyWith(groupAdmins: testGroupAdmins);
 
@@ -162,38 +167,46 @@ void main() {
         notifier.state = notifier.state.copyWith(groups: testGroups);
       });
 
-      test('getGroupsByType should filter by GroupType.group', () async {
-        final notifier = container.read(groupsProvider.notifier);
+      test(
+        'getGroupsByType should filter by GroupType.group',
+        () async {
+          final notifier = container.read(groupsProvider.notifier);
 
-        // Skip test when rust bridge is not available
-        try {
-          final regularGroups = await notifier.getGroupsByType(GroupType.group);
-          expect(regularGroups.length, 2);
-          expect(regularGroups.map((g) => g.name), contains('Test Group 1'));
-          expect(regularGroups.map((g) => g.name), contains('Inactive Group'));
-        } catch (e) {
-          // Skip test if rust bridge is not initialized
-          if (e.toString().contains('flutter_rust_bridge has not been initialized')) {
-            return;
+          // Skip test when rust bridge is not available
+          try {
+            final regularGroups = await notifier.getGroupsByType(GroupType.group);
+            expect(regularGroups.length, 2);
+            expect(regularGroups.map((g) => g.name), contains('Test Group 1'));
+            expect(regularGroups.map((g) => g.name), contains('Inactive Group'));
+          } catch (e) {
+            // Skip test if rust bridge is not initialized
+            if (e.toString().contains('flutter_rust_bridge has not been initialized')) {
+              return;
+            }
+            rethrow;
           }
-          rethrow;
-        }
-      }, skip: 'Requires rust bridge initialization');
+        },
+        skip: 'Requires rust bridge initialization',
+      );
 
-      test('getGroupsByType should filter by GroupType.directMessage', () async {
-        final notifier = container.read(groupsProvider.notifier);
+      test(
+        'getGroupsByType should filter by GroupType.directMessage',
+        () async {
+          final notifier = container.read(groupsProvider.notifier);
 
-        try {
-          final dmGroups = await notifier.getGroupsByType(GroupType.directMessage);
-          expect(dmGroups.length, 1);
-          expect(dmGroups.first.name, 'Direct Message');
-        } catch (e) {
-          if (e.toString().contains('flutter_rust_bridge has not been initialized')) {
-            return;
+          try {
+            final dmGroups = await notifier.getGroupsByType(GroupType.directMessage);
+            expect(dmGroups.length, 1);
+            expect(dmGroups.first.name, 'Direct Message');
+          } catch (e) {
+            if (e.toString().contains('flutter_rust_bridge has not been initialized')) {
+              return;
+            }
+            rethrow;
           }
-          rethrow;
-        }
-      }, skip: 'Requires rust bridge initialization');
+        },
+        skip: 'Requires rust bridge initialization',
+      );
 
       test('getActiveGroups should filter by GroupState.active', () {
         final notifier = container.read(groupsProvider.notifier);
@@ -205,35 +218,46 @@ void main() {
         expect(activeGroups.map((g) => g.name), contains('Direct Message'));
       });
 
-      test('getDirectMessageGroups should return only direct messages', () async {
-        final notifier = container.read(groupsProvider.notifier);
+      test(
+        'getDirectMessageGroups should return only direct messages',
+        () async {
+          final notifier = container.read(groupsProvider.notifier);
 
-        try {
-          final dmGroups = await notifier.getDirectMessageGroups();
-          expect(dmGroups.length, 1);
-          expect(dmGroups.first.name, 'Direct Message');
-        } catch (e) {
-          if (e.toString().contains('flutter_rust_bridge has not been initialized')) {
-            return;
+          try {
+            final dmGroups = await notifier.getDirectMessageGroups();
+            expect(dmGroups.length, 1);
+            expect(dmGroups.first.name, 'Direct Message');
+          } catch (e) {
+            if (e.toString().contains('flutter_rust_bridge has not been initialized')) {
+              return;
+            }
+            rethrow;
           }
-          rethrow;
-        }
-      }, skip: 'Requires rust bridge initialization');
+        },
+        skip: 'Requires rust bridge initialization',
+      );
 
-      test('getRegularGroups should return only regular groups', () async {
-        final notifier = container.read(groupsProvider.notifier);
+      test(
+        'getRegularGroups should return only regular groups',
+        () async {
+          final notifier = container.read(groupsProvider.notifier);
 
-        try {
-          final regularGroups = await notifier.getRegularGroups();
-          expect(regularGroups.length, 2);
-          expect(regularGroups.map((g) => g.name), containsAll(['Test Group 1', 'Inactive Group']));
-        } catch (e) {
-          if (e.toString().contains('flutter_rust_bridge has not been initialized')) {
-            return;
+          try {
+            final regularGroups = await notifier.getRegularGroups();
+            expect(regularGroups.length, 2);
+            expect(
+              regularGroups.map((g) => g.name),
+              containsAll(['Test Group 1', 'Inactive Group']),
+            );
+          } catch (e) {
+            if (e.toString().contains('flutter_rust_bridge has not been initialized')) {
+              return;
+            }
+            rethrow;
           }
-          rethrow;
-        }
-      }, skip: 'Requires rust bridge initialization');
+        },
+        skip: 'Requires rust bridge initialization',
+      );
 
       test('findGroupById should find group by mlsGroupId', () {
         final notifier = container.read(groupsProvider.notifier);
@@ -268,7 +292,9 @@ void main() {
           nip05: 'member@example.com',
           publicKey: 'member_pubkey',
         );
-        final testGroupMembers = <String, List<User>>{'group1': [testUser]};
+        final testGroupMembers = <String, List<User>>{
+          'group1': [testUser],
+        };
         notifier.state = notifier.state.copyWith(groupMembers: testGroupMembers);
 
         final members = notifier.getGroupMembers('group1');
@@ -289,7 +315,9 @@ void main() {
           nip05: 'admin@example.com',
           publicKey: 'admin_pubkey',
         );
-        final testGroupAdmins = <String, List<User>>{'group1': [testUser]};
+        final testGroupAdmins = <String, List<User>>{
+          'group1': [testUser],
+        };
         notifier.state = notifier.state.copyWith(groupAdmins: testGroupAdmins);
 
         final admins = notifier.getGroupAdmins('group1');
@@ -314,8 +342,12 @@ void main() {
         );
         notifier.state = notifier.state.copyWith(
           groups: testGroups,
-          groupMembers: <String, List<User>>{'test': [testUser]},
-          groupAdmins: <String, List<User>>{'test': [testUser]},
+          groupMembers: <String, List<User>>{
+            'test': [testUser],
+          },
+          groupAdmins: <String, List<User>>{
+            'test': [testUser],
+          },
           groupDisplayNames: <String, String>{'test': 'Test Group'},
           error: 'some error',
         );
@@ -604,7 +636,7 @@ void main() {
     });
 
     group('Data Validation', () {
-            test('should correctly identify group types', () async {
+      test('should correctly identify group types', () async {
         final notifier = container.read(groupsProvider.notifier);
         notifier.state = notifier.state.copyWith(groups: testGroups);
 

--- a/test/config/providers/profile_ready_card_visibility_provider_test.dart
+++ b/test/config/providers/profile_ready_card_visibility_provider_test.dart
@@ -32,6 +32,7 @@ class _MockFailingSharedPreferences implements SharedPreferences {
 
 void main() {
   group('ProfileReadyCardVisibilityProvider Tests', () {
+    TestWidgetsFlutterBinding.ensureInitialized();
     late ProviderContainer container;
     late ProfileReadyCardVisibilityNotifier notifier;
 

--- a/test/config/providers/welcomes_provider_test.dart
+++ b/test/config/providers/welcomes_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:whitenoise/src/rust/api/welcomes.dart';
 
 void main() {
   group('WelcomesProvider Tests', () {
+    TestWidgetsFlutterBinding.ensureInitialized();
     late ProviderContainer container;
 
     // Test data
@@ -820,9 +821,10 @@ void main() {
         );
 
         // Find new pending welcomes and trigger callback for the first one
-        final newPendingWelcomes = newWelcomes
-            .where((w) => w.state == WelcomeState.pending && !previousPendingIds.contains(w.id))
-            .toList();
+        final newPendingWelcomes =
+            newWelcomes
+                .where((w) => w.state == WelcomeState.pending && !previousPendingIds.contains(w.id))
+                .toList();
 
         if (newPendingWelcomes.isNotEmpty) {
           notifier.triggerWelcomeCallback(newPendingWelcomes.first);

--- a/test/ui/contact_list/services/welcome_notification_service_simple_test.dart
+++ b/test/ui/contact_list/services/welcome_notification_service_simple_test.dart
@@ -6,6 +6,7 @@ import 'package:whitenoise/ui/contact_list/services/welcome_notification_service
 
 void main() {
   group('WelcomeNotificationService Core Tests', () {
+    TestWidgetsFlutterBinding.ensureInitialized();
     late ProviderContainer container;
 
     // Test data

--- a/test/ui/contact_list/start_chat_bottom_sheet_test.dart
+++ b/test/ui/contact_list/start_chat_bottom_sheet_test.dart
@@ -22,6 +22,11 @@ class MockFollowsNotifier extends FollowsNotifier {
       follows: _mockFollows,
     );
   }
+
+  @override
+  bool isFollowing(String pubkey) {
+    return _mockFollows.any((user) => user.pubkey == pubkey);
+  }
 }
 
 class MockActiveAccountNotifier extends ActiveAccountNotifier {
@@ -68,19 +73,6 @@ void main() {
       publicKey: 'abc123def456789012345678901234567890123456789012345678901234567890',
       nip05: 'satoshi@nakamoto.com',
       imagePath: 'https://example.com/satoshi.png',
-    );
-
-    final mockUser = User(
-      pubkey: 'abc123def456789012345678901234567890123456789012345678901234567890',
-      metadata: const FlutterMetadata(
-        name: 'Satoshi Nakamoto',
-        displayName: 'Satoshi Nakamoto',
-        nip05: 'satoshi@nakamoto.com',
-        picture: 'https://example.com/satoshi.png',
-        custom: {},
-      ),
-      createdAt: DateTime.now(),
-      updatedAt: DateTime.now(),
     );
 
     // Common provider overrides for all tests
@@ -225,6 +217,11 @@ void main() {
         expect(find.text('Add to Group'), findsOneWidget);
       });
 
+      testWidgets('hides remove contact option', (WidgetTester tester) async {
+        await setup(tester);
+        expect(find.text('Remove Contact'), findsNothing);
+      });
+
       testWidgets('displays start chat option', (WidgetTester tester) async {
         await setup(tester);
         expect(find.text('Start Chat'), findsOneWidget);
@@ -245,7 +242,16 @@ void main() {
               ),
               overrides: [
                 ...commonOverrides,
-                followsProvider.overrideWith(() => MockFollowsNotifier([mockUser])),
+                followsProvider.overrideWith(
+                  () => MockFollowsNotifier([
+                    User(
+                      pubkey: contact.publicKey,
+                      metadata: const FlutterMetadata(custom: {}),
+                      createdAt: DateTime.now(),
+                      updatedAt: DateTime.now(),
+                    ),
+                  ]),
+                ),
               ],
             ),
           );
@@ -253,46 +259,12 @@ void main() {
         }
 
         testWidgets('displays remove contact option', (WidgetTester tester) async {
-          await tester.pumpWidget(
-            createTestWidget(
-              StartChatBottomSheet(
-                contact: contact,
-                usersApi: MockWnUsersApiWithPackage(),
-              ),
-              overrides: [
-                ...commonOverrides,
-                followsProvider.overrideWith(() => MockFollowsNotifier([User(
-                  pubkey: contact.publicKey,
-                  metadata: const FlutterMetadata(custom: {}),
-                  createdAt: DateTime.now(),
-                  updatedAt: DateTime.now(),
-                )])),
-              ],
-            ),
-          );
-          await tester.pumpAndSettle();
+          await setup(tester);
           expect(find.text('Remove Contact'), findsOneWidget);
         });
 
         testWidgets('hides add contact option', (WidgetTester tester) async {
-          await tester.pumpWidget(
-            createTestWidget(
-              StartChatBottomSheet(
-                contact: contact,
-                usersApi: MockWnUsersApiWithPackage(),
-              ),
-              overrides: [
-                ...commonOverrides,
-                followsProvider.overrideWith(() => MockFollowsNotifier([User(
-                  pubkey: contact.publicKey,
-                  metadata: const FlutterMetadata(custom: {}),
-                  createdAt: DateTime.now(),
-                  updatedAt: DateTime.now(),
-                )])),
-              ],
-            ),
-          );
-          await tester.pumpAndSettle();
+          await setup(tester);
           expect(find.text('Add Contact'), findsNothing);
         });
 

--- a/test/utils/pubkey_formatter_test.dart
+++ b/test/utils/pubkey_formatter_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:whitenoise/utils/pubkey_formatter.dart';
+
+void main() {
+  group('PubkeyFormatter Tests', () {
+    const testNpubPubkey = 'npub1zygjyg3nxdzyg424ven8waug3zvejqqq424thw7venwammhwlllsj2q4yf';
+    const testHexPubkey = '1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff';
+    const otherTestNpubPubkey = 'npub140x77qfrg4ncnlkuh2v8v4pjzz4ummcpydzk0z07mjafsaj5xggq9d4zqy';
+    const otherTestHexPubkey = 'abcdef0123456789fedcba9876543210abcdef0123456789fedcba9876543210';
+
+    const npubHexMap = {
+      testNpubPubkey: testHexPubkey,
+      otherTestNpubPubkey: otherTestHexPubkey,
+    };
+
+    const hexNpubMap = {
+      testHexPubkey: testNpubPubkey,
+      otherTestHexPubkey: otherTestNpubPubkey,
+    };
+
+    late PubkeyFormatter formatter;
+    late String? Function({required String hexPubkey}) mockNpubFromHexPubkey;
+    late String? Function({required String npub}) mockHexPubkeyFromNpub;
+
+    setUp(() {
+      mockNpubFromHexPubkey = ({required String hexPubkey}) => hexNpubMap[hexPubkey];
+      mockHexPubkeyFromNpub = ({required String npub}) => npubHexMap[npub];
+    });
+
+    group('toNpub', () {
+      test('returns npub when input is already npub', () {
+        formatter = PubkeyFormatter(
+          pubkey: testNpubPubkey,
+          npubFromHexPubkey: mockNpubFromHexPubkey,
+          hexPubkeyFromNpub: mockHexPubkeyFromNpub,
+        );
+
+        final result = formatter.toNpub();
+        expect(result, equals(testNpubPubkey));
+      });
+
+      test('converts hex to npub', () {
+        formatter = PubkeyFormatter(
+          pubkey: testHexPubkey,
+          npubFromHexPubkey: mockNpubFromHexPubkey,
+          hexPubkeyFromNpub: mockHexPubkeyFromNpub,
+        );
+
+        final result = formatter.toNpub();
+        expect(result, equals(testNpubPubkey));
+      });
+
+      test('trims and converts hex to npub', () {
+        formatter = PubkeyFormatter(
+          pubkey: ' $testHexPubkey ',
+          npubFromHexPubkey: mockNpubFromHexPubkey,
+          hexPubkeyFromNpub: mockHexPubkeyFromNpub,
+        );
+
+        final result = formatter.toNpub();
+        expect(result, equals(testNpubPubkey));
+      });
+
+      test('converts other hex to npub', () {
+        formatter = PubkeyFormatter(
+          pubkey: otherTestHexPubkey,
+          npubFromHexPubkey: mockNpubFromHexPubkey,
+          hexPubkeyFromNpub: mockHexPubkeyFromNpub,
+        );
+
+        final result = formatter.toNpub();
+        expect(result, equals(otherTestNpubPubkey));
+      });
+
+      test('returns null for invalid pubkey', () {
+        formatter = PubkeyFormatter(
+          pubkey: 'invalid',
+          npubFromHexPubkey: mockNpubFromHexPubkey,
+          hexPubkeyFromNpub: mockHexPubkeyFromNpub,
+        );
+
+        final result = formatter.toNpub();
+        expect(result, isNull);
+      });
+
+      test('returns null when pubkey is null', () {
+        formatter = PubkeyFormatter(
+          npubFromHexPubkey: mockNpubFromHexPubkey,
+          hexPubkeyFromNpub: mockHexPubkeyFromNpub,
+        );
+
+        final result = formatter.toNpub();
+        expect(result, isNull);
+      });
+    });
+
+    group('toHex', () {
+      test('returns hex when input is already hex', () {
+        formatter = PubkeyFormatter(
+          pubkey: testHexPubkey,
+          npubFromHexPubkey: mockNpubFromHexPubkey,
+          hexPubkeyFromNpub: mockHexPubkeyFromNpub,
+        );
+
+        final result = formatter.toHex();
+        expect(result, equals(testHexPubkey));
+      });
+
+      test('converts npub to hex', () {
+        formatter = PubkeyFormatter(
+          pubkey: testNpubPubkey,
+          npubFromHexPubkey: mockNpubFromHexPubkey,
+          hexPubkeyFromNpub: mockHexPubkeyFromNpub,
+        );
+
+        final result = formatter.toHex();
+        expect(result, testHexPubkey);
+      });
+
+      test('trims and converts npub to hex', () {
+        formatter = PubkeyFormatter(
+          pubkey: ' $testNpubPubkey ',
+          npubFromHexPubkey: mockNpubFromHexPubkey,
+          hexPubkeyFromNpub: mockHexPubkeyFromNpub,
+        );
+
+        final result = formatter.toHex();
+        expect(result, testHexPubkey);
+      });
+
+      test('converts other npub to hex', () {
+        formatter = PubkeyFormatter(
+          pubkey: otherTestNpubPubkey,
+          npubFromHexPubkey: mockNpubFromHexPubkey,
+          hexPubkeyFromNpub: mockHexPubkeyFromNpub,
+        );
+
+        final result = formatter.toHex();
+        expect(result, equals(otherTestHexPubkey));
+      });
+
+      test('returns null for invalid pubkey', () {
+        formatter = PubkeyFormatter(
+          pubkey: 'invalid',
+          npubFromHexPubkey: mockNpubFromHexPubkey,
+          hexPubkeyFromNpub: mockHexPubkeyFromNpub,
+        );
+
+        final result = formatter.toHex();
+        expect(result, isNull);
+      });
+
+      test('returns null when pubkey is null', () {
+        formatter = PubkeyFormatter(
+          npubFromHexPubkey: mockNpubFromHexPubkey,
+          hexPubkeyFromNpub: mockHexPubkeyFromNpub,
+        );
+
+        final result = formatter.toHex();
+        expect(result, isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
In #594, CodeRabbit left some comments about trimming and the active pubkey format. That made me realize it wasn’t guaranteed that the value saved in secure storage for a pubkey was consistently in hex format. To ensure consistency, we need to format it before saving. Also code rabbit noticed that in some places pubkey comparison could be in different formats. 

My first approach was to use the string extensions .toHex and .toNpub. The problem is that these extensions are hard to mock in tests (and in this case mocking was needed, since the methods call Rust bridge functions). I changed the approach by moving those methods into a new class called PublicKeyFormatter. This made testing in the active pubkey provider much easier. I also replaced the string extension calls and the direct Rust API calls for pubkey formatting with this new util.

**Commit by commit:**
- Adds pubkey formatter util
- Fixes format in active pubkey provider, guaranteeing hex
- Replaces use of string extensions .toHex and .toNpub with new formatter
- Replaces use of direct rust api methods for formatting with the new formatter
- Fixes pubkeys comparisons by guaranteen that pubnkeys are compared in same format

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [x] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accept NPUB/bech32 or HEX pubkeys and consistently display/store them as HEX with injectable formatting.

* **Bug Fixes**
  * Fixed inconsistent pubkey comparisons across chats, groups, contacts, and account switching.
  * Improved fallback behavior when pubkey formatting fails.

* **Refactor**
  * Centralized pubkey conversion and normalization across providers and UI flows.

* **Tests**
  * Added unit tests for the pubkey formatter and updated test initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->