### PR TITLE
fix: show invite when keypackage fetch fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed get user logic, to show metadata when searching a new npub
 - Fixes profile edition with outdated metadata
 - Fixes pubkeys formatting and pubkeys comparisons in different format
+- Fixes follow/unfollow in start chat sheet
 
 ### Security
 

--- a/lib/config/providers/follow_provider.dart
+++ b/lib/config/providers/follow_provider.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+import 'package:whitenoise/config/providers/active_pubkey_provider.dart';
+import 'package:whitenoise/config/providers/follows_provider.dart';
+import 'package:whitenoise/src/rust/api/accounts.dart' as accounts_api;
+
+class FollowState {
+  final bool isFollowing;
+  final bool isLoading;
+  final String? error;
+
+  const FollowState({
+    this.isFollowing = false,
+    this.isLoading = false,
+    this.error,
+  });
+
+  FollowState copyWith({
+    bool? isFollowing,
+    bool? isLoading,
+    String? error,
+  }) {
+    return FollowState(
+      isFollowing: isFollowing ?? this.isFollowing,
+      isLoading: isLoading ?? this.isLoading,
+      error: error,
+    );
+  }
+}
+
+class FollowNotifier extends FamilyNotifier<FollowState, String> {
+  final _logger = Logger('FollowNotifier');
+
+  @override
+  FollowState build(String pubkey) {
+    ref.listen<String?>(activePubkeyProvider, (previous, next) {
+      if (previous != next) {
+        ref.invalidateSelf();
+      }
+    });
+
+    final followsNotifier = ref.read(followsProvider.notifier);
+    final isFollowing = followsNotifier.isFollowing(pubkey);
+
+    return FollowState(isFollowing: isFollowing);
+  }
+
+  bool isFollow(String pubkey) {
+    return state.isFollowing;
+  }
+
+  Future<void> addFollow(String pubkey) async {
+    final activePubkey = ref.read(activePubkeyProvider);
+    if (activePubkey == null) {
+      state = state.copyWith(error: 'No active account found');
+      return;
+    }
+
+    state = state.copyWith(isLoading: true);
+
+    try {
+      await accounts_api.followUser(
+        accountPubkey: activePubkey,
+        userToFollowPubkey: pubkey,
+      );
+      await ref.read(followsProvider.notifier).loadFollows();
+      state = state.copyWith(isFollowing: true, isLoading: false);
+
+      _logger.info('Successfully followed user: $pubkey');
+    } catch (e) {
+      _logger.severe('Failed to follow user: $e');
+      state = state.copyWith(error: 'Failed to follow user', isLoading: false);
+    }
+  }
+
+  Future<void> removeFollow(String pubkey) async {
+    final activePubkey = ref.read(activePubkeyProvider);
+    if (activePubkey == null) {
+      state = state.copyWith(error: 'No active account found');
+      return;
+    }
+
+    state = state.copyWith(isLoading: true);
+
+    try {
+      await accounts_api.unfollowUser(
+        accountPubkey: activePubkey,
+        userToUnfollowPubkey: pubkey,
+      );
+      await ref.read(followsProvider.notifier).loadFollows();
+      state = state.copyWith(isFollowing: false, isLoading: false);
+
+      _logger.info('Successfully unfollowed user: $pubkey');
+    } catch (e) {
+      _logger.severe('Failed to unfollow user: $e');
+      state = state.copyWith(error: 'Failed to unfollow user', isLoading: false);
+    }
+  }
+}
+
+final followProvider = NotifierProvider.family<FollowNotifier, FollowState, String>(
+  FollowNotifier.new,
+);

--- a/lib/config/providers/follows_provider.dart
+++ b/lib/config/providers/follows_provider.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_redundant_argument_values
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:whitenoise/config/providers/active_pubkey_provider.dart';
@@ -71,7 +69,7 @@ class FollowsNotifier extends Notifier<FollowsState> {
   Future<void> loadFollows() async {
     if (state.isLoading) return;
 
-    state = state.copyWith(isLoading: true, error: null);
+    state = state.copyWith(isLoading: true);
 
     if (!_isAuthAvailable()) {
       state = state.copyWith(isLoading: false);
@@ -130,6 +128,7 @@ class FollowsNotifier extends Notifier<FollowsState> {
       _logger.info('FollowsProvider: Successfully followed user: $userPubkey');
 
       await loadFollows();
+      state = state.copyWith(isLoading: false);
     } catch (e, st) {
       _logger.severe('FollowsProvider.addFollow - Exception: $e (Type: ${e.runtimeType})', e, st);
 
@@ -167,6 +166,7 @@ class FollowsNotifier extends Notifier<FollowsState> {
       _logger.info('FollowsProvider: Successfully unfollowed user: $userPubkey');
 
       await loadFollows();
+      state = state.copyWith(isLoading: false);
     } catch (e, st) {
       _logger.severe(
         'FollowsProvider.removeFollow - Exception: $e (Type: ${e.runtimeType})',

--- a/lib/config/providers/follows_provider.dart
+++ b/lib/config/providers/follows_provider.dart
@@ -105,86 +105,6 @@ class FollowsNotifier extends Notifier<FollowsState> {
     }
   }
 
-  Future<void> addFollow(String userPubkey) async {
-    state = state.copyWith(isLoading: true, error: null);
-
-    if (!_isAuthAvailable()) {
-      state = state.copyWith(isLoading: false);
-      return;
-    }
-
-    try {
-      final activePubkey = ref.read(activePubkeyProvider) ?? '';
-      if (activePubkey.isEmpty) {
-        state = state.copyWith(error: 'No active account found', isLoading: false);
-        return;
-      }
-
-      await accounts_api.followUser(
-        accountPubkey: activePubkey,
-        userToFollowPubkey: userPubkey,
-      );
-
-      _logger.info('FollowsProvider: Successfully followed user: $userPubkey');
-
-      await loadFollows();
-      state = state.copyWith(isLoading: false);
-    } catch (e, st) {
-      _logger.severe('FollowsProvider.addFollow - Exception: $e (Type: ${e.runtimeType})', e, st);
-
-      final errorMessage = await ErrorHandlingUtils.convertErrorToUserFriendlyMessage(
-        error: e,
-        stackTrace: st,
-        fallbackMessage: 'Failed to add follow. Please try again.',
-        context: 'addFollow',
-      );
-
-      state = state.copyWith(error: errorMessage, isLoading: false);
-    }
-  }
-
-  Future<void> removeFollow(String userPubkey) async {
-    state = state.copyWith(isLoading: true, error: null);
-
-    if (!_isAuthAvailable()) {
-      state = state.copyWith(isLoading: false);
-      return;
-    }
-
-    try {
-      final activePubkey = ref.read(activePubkeyProvider) ?? '';
-      if (activePubkey.isEmpty) {
-        state = state.copyWith(error: 'No active account found', isLoading: false);
-        return;
-      }
-
-      await accounts_api.unfollowUser(
-        accountPubkey: activePubkey,
-        userToUnfollowPubkey: userPubkey,
-      );
-
-      _logger.info('FollowsProvider: Successfully unfollowed user: $userPubkey');
-
-      await loadFollows();
-      state = state.copyWith(isLoading: false);
-    } catch (e, st) {
-      _logger.severe(
-        'FollowsProvider.removeFollow - Exception: $e (Type: ${e.runtimeType})',
-        e,
-        st,
-      );
-
-      final errorMessage = await ErrorHandlingUtils.convertErrorToUserFriendlyMessage(
-        error: e,
-        stackTrace: st,
-        fallbackMessage: 'Failed to remove follow. Please try again.',
-        context: 'removeFollow',
-      );
-
-      state = state.copyWith(error: errorMessage, isLoading: false);
-    }
-  }
-
   void clearFollows() {
     state = const FollowsState();
   }
@@ -204,10 +124,6 @@ class FollowsNotifier extends Notifier<FollowsState> {
   }
 
   List<User> get allFollows => state.follows;
-
-  Future<void> refreshFollows() async {
-    await loadFollows();
-  }
 }
 
 final followsProvider = NotifierProvider<FollowsNotifier, FollowsState>(

--- a/lib/ui/chat/chat_info/chat_info_screen.dart
+++ b/lib/ui/chat/chat_info/chat_info_screen.dart
@@ -7,6 +7,7 @@ import 'package:logging/logging.dart';
 import 'package:whitenoise/config/extensions/toast_extension.dart';
 import 'package:whitenoise/config/providers/active_pubkey_provider.dart';
 import 'package:whitenoise/config/providers/chat_search_provider.dart';
+import 'package:whitenoise/config/providers/follow_provider.dart';
 import 'package:whitenoise/config/providers/follows_provider.dart';
 import 'package:whitenoise/config/providers/group_provider.dart';
 import 'package:whitenoise/domain/models/dm_chat_data.dart';

--- a/lib/ui/chat/chat_info/widgets/member_action_buttons.dart
+++ b/lib/ui/chat/chat_info/widgets/member_action_buttons.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:logging/logging.dart';
 import 'package:whitenoise/config/extensions/toast_extension.dart';
-import 'package:whitenoise/config/providers/follows_provider.dart';
+import 'package:whitenoise/config/providers/follow_provider.dart';
 import 'package:whitenoise/config/providers/group_provider.dart';
 import 'package:whitenoise/domain/models/user_model.dart';
 import 'package:whitenoise/routing/chat_navigation_extension.dart';
@@ -11,7 +11,6 @@ import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
 import 'package:whitenoise/ui/core/ui/wn_button.dart';
 import 'package:whitenoise/ui/core/ui/wn_image.dart';
-import 'package:whitenoise/utils/pubkey_formatter.dart';
 
 class SendMessageButton extends ConsumerStatefulWidget {
   const SendMessageButton(this.user, {super.key});
@@ -104,67 +103,40 @@ class AddToContactButton extends ConsumerStatefulWidget {
 }
 
 class _AddToContactButtonState extends ConsumerState<AddToContactButton> {
-  bool _isAddingContact = false;
-  bool get _isLoading => _isAddingContact;
+  Future<void> _toggleFollow() async {
+    final followNotifier = ref.read(followProvider(widget.user.publicKey).notifier);
+    var currentFollowState = ref.read(followProvider(widget.user.publicKey));
+    late String successMessage;
 
-  bool _isContact() {
-    final followsState = ref.watch(followsProvider);
-    final follows = followsState.follows;
+    if (currentFollowState.isFollowing) {
+      successMessage = 'Unfollowed ${widget.user.displayName}';
+      await followNotifier.removeFollow(widget.user.publicKey);
+    } else {
+      successMessage = 'Followed ${widget.user.displayName}';
+      await followNotifier.addFollow(widget.user.publicKey);
+    }
 
-    return follows.any(
-      (follow) {
-        final hexFollowPubkey = PubkeyFormatter(pubkey: follow.pubkey).toHex();
-        final hexUserPubkey = PubkeyFormatter(pubkey: widget.user.publicKey).toHex();
-        if (hexFollowPubkey == null || hexUserPubkey == null) return false;
-        return hexFollowPubkey == hexUserPubkey;
-      },
-    );
-  }
-
-  Future<void> _toggleContact() async {
-    setState(() {
-      _isAddingContact = true;
-    });
-
-    try {
-      final followsNotifier = ref.read(followsProvider.notifier);
-      final isCurrentlyFollow = followsNotifier.isFollowing(widget.user.publicKey);
-
-      if (isCurrentlyFollow) {
-        await followsNotifier.removeFollow(widget.user.publicKey);
-        if (mounted) {
-          ref.showSuccessToast('${widget.user.displayName} removed from follows');
-        }
-      } else {
-        await followsNotifier.addFollow(widget.user.publicKey);
-        if (mounted) {
-          ref.showSuccessToast('${widget.user.displayName} added to follows');
-        }
-      }
-    } catch (e) {
-      if (mounted) {
-        ref.showErrorToast('Failed to update follow: $e');
-      }
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isAddingContact = false;
-        });
-      }
+    currentFollowState = ref.read(followProvider(widget.user.publicKey));
+    final errorMessage = currentFollowState.error ?? '';
+    if (errorMessage.isNotEmpty) {
+      ref.showErrorToast(errorMessage);
+    } else {
+      ref.showSuccessToast(successMessage);
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    final isContact = _isContact();
+    final followState = ref.watch(followProvider(widget.user.publicKey));
+
     return WnFilledButton(
-      onPressed: _toggleContact,
-      loading: _isLoading,
+      onPressed: followState.isLoading ? null : _toggleFollow,
+      loading: followState.isLoading,
       size: WnButtonSize.small,
       visualState: WnButtonVisualState.secondary,
-      label: isContact ? 'Remove Contact' : 'Add Contact',
+      label: followState.isFollowing ? 'Unfollow' : 'Follow',
       suffixIcon: WnImage(
-        isContact ? AssetsPaths.icRemoveUser : AssetsPaths.icAddUser,
+        followState.isFollowing ? AssetsPaths.icRemoveUser : AssetsPaths.icAddUser,
         size: 11.w,
         color: context.colors.primary,
       ),

--- a/lib/ui/contact_list/new_chat_bottom_sheet.dart
+++ b/lib/ui/contact_list/new_chat_bottom_sheet.dart
@@ -506,28 +506,12 @@ class _NewChatBottomSheetState extends ConsumerState<NewChatBottomSheet> {
                             ),
                           ),
                         ] else ...[
-                          // Contacts list - all follows as individual widgets in the scroll view
                           ...filteredContacts.map(
                             (contact) => Padding(
                               padding: EdgeInsets.only(bottom: 4.h),
                               child: ContactListTile(
                                 contact: contact,
-                                enableSwipeToDelete: true,
                                 onTap: () => _handleContactTap(contact),
-                                onDelete: () async {
-                                  try {
-                                    await ref
-                                        .read(followsProvider.notifier)
-                                        .removeFollow(contact.publicKey);
-                                    if (context.mounted) {
-                                      ref.showSuccessToast('Contact removed successfully');
-                                    }
-                                  } catch (e) {
-                                    if (context.mounted) {
-                                      ref.showErrorToast('Failed to remove contact: $e');
-                                    }
-                                  }
-                                },
                               ),
                             ),
                           ),

--- a/lib/ui/contact_list/new_group_chat_sheet.dart
+++ b/lib/ui/contact_list/new_group_chat_sheet.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
-import 'package:whitenoise/config/extensions/toast_extension.dart';
 import 'package:whitenoise/config/providers/active_pubkey_provider.dart';
 import 'package:whitenoise/config/providers/follows_provider.dart';
 import 'package:whitenoise/domain/models/contact_model.dart';
@@ -91,19 +90,6 @@ class _NewGroupChatSheetState extends ConsumerState<NewGroupChatSheet> {
           contact: contact,
           isSelected: isSelected,
           onTap: () => _toggleContactSelection(contact),
-          enableSwipeToDelete: true,
-          onDelete: () async {
-            try {
-              await ref.read(followsProvider.notifier).removeFollow(contact.publicKey);
-              if (context.mounted) {
-                ref.showSuccessToast('Contact removed successfully');
-              }
-            } catch (e) {
-              if (context.mounted) {
-                ref.showErrorToast('Failed to remove contact: $e');
-              }
-            }
-          },
           showCheck: true,
         );
       },

--- a/lib/ui/contact_list/start_chat_bottom_sheet.dart
+++ b/lib/ui/contact_list/start_chat_bottom_sheet.dart
@@ -98,20 +98,11 @@ class _StartChatBottomSheetState extends ConsumerState<StartChatBottomSheet> {
         });
       }
     } catch (e) {
-      String error;
-      if (e is ApiError) {
-        error = await e.messageText();
-      } else {
-        error = e.toString();
-      }
-      _logger.warning('Failed to fetch key package: $error');
-      if (mounted) {
-        setState(() {
-          _isLoadingKeyPackage = false;
-          _isLoadingKeyPackageError = true;
-          ref.showErrorToast('Error loading user key package: $e');
-        });
-      }
+      _logger.warning('Failed to fetch key package: $e');
+      setState(() {
+        _isLoadingKeyPackage = false;
+        _needsInvite = true;
+      });
     }
   }
 

--- a/lib/ui/contact_list/start_chat_bottom_sheet.dart
+++ b/lib/ui/contact_list/start_chat_bottom_sheet.dart
@@ -7,7 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 import 'package:whitenoise/config/extensions/toast_extension.dart';
 import 'package:whitenoise/config/providers/active_account_provider.dart';
-import 'package:whitenoise/config/providers/follows_provider.dart';
+import 'package:whitenoise/config/providers/follow_provider.dart';
 import 'package:whitenoise/config/providers/group_provider.dart';
 import 'package:whitenoise/config/providers/profile_ready_card_visibility_provider.dart';
 import 'package:whitenoise/domain/models/contact_model.dart';
@@ -71,7 +71,6 @@ class StartChatBottomSheet extends ConsumerStatefulWidget {
 class _StartChatBottomSheetState extends ConsumerState<StartChatBottomSheet> {
   final _logger = Logger('StartChatBottomSheet');
   bool _isCreatingGroup = false;
-  bool _isAddingContact = false;
   bool _isLoadingKeyPackage = true;
   bool _isLoadingKeyPackageError = false;
   bool _needsInvite = false;
@@ -110,7 +109,7 @@ class _StartChatBottomSheetState extends ConsumerState<StartChatBottomSheet> {
         setState(() {
           _isLoadingKeyPackage = false;
           _isLoadingKeyPackageError = true;
-          ref.showErrorToast('Error loading contact: $e');
+          ref.showErrorToast('Error loading user key package: $e');
         });
       }
     }
@@ -167,41 +166,24 @@ class _StartChatBottomSheetState extends ConsumerState<StartChatBottomSheet> {
     }
   }
 
-  bool _isFollow() {
-    final followsNotifier = ref.read(followsProvider.notifier);
-    return followsNotifier.isFollowing(widget.contact.publicKey);
-  }
+  Future<void> _toggleFollow() async {
+    final followNotifier = ref.read(followProvider(widget.contact.publicKey).notifier);
+    var currentFollowState = ref.read(followProvider(widget.contact.publicKey));
+    late String successMessage;
+    if (currentFollowState.isFollowing) {
+      successMessage = 'Unfollowed ${widget.contact.displayName}';
+      await followNotifier.removeFollow(widget.contact.publicKey);
+    } else {
+      successMessage = 'Followed ${widget.contact.displayName}';
+      await followNotifier.addFollow(widget.contact.publicKey);
+    }
 
-  Future<void> _toggleContact() async {
-    setState(() {
-      _isAddingContact = true;
-    });
-
-    try {
-      final followsNotifier = ref.read(followsProvider.notifier);
-      final isCurrentlyFollow = followsNotifier.isFollowing(widget.contact.publicKey);
-
-      if (isCurrentlyFollow) {
-        await followsNotifier.removeFollow(widget.contact.publicKey);
-        if (mounted) {
-          ref.showSuccessToast('${widget.contact.displayName} removed from contacts');
-        }
-      } else {
-        await followsNotifier.addFollow(widget.contact.publicKey);
-        if (mounted) {
-          ref.showSuccessToast('${widget.contact.displayName} added to contacts');
-        }
-      }
-    } catch (e) {
-      if (mounted) {
-        ref.showErrorToast('Failed to update contact: $e');
-      }
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isAddingContact = false;
-        });
-      }
+    currentFollowState = ref.read(followProvider(widget.contact.publicKey));
+    final errorMessage = currentFollowState.error ?? '';
+    if (errorMessage.isNotEmpty) {
+      ref.showErrorToast(errorMessage);
+    } else {
+      ref.showSuccessToast(successMessage);
     }
   }
 
@@ -215,6 +197,8 @@ class _StartChatBottomSheetState extends ConsumerState<StartChatBottomSheet> {
 
   @override
   Widget build(BuildContext context) {
+    final followState = ref.watch(followProvider(widget.contact.publicKey));
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -271,10 +255,13 @@ class _StartChatBottomSheetState extends ConsumerState<StartChatBottomSheet> {
                       children: [
                         WnFilledButton(
                           visualState: WnButtonVisualState.secondary,
-                          onPressed: _isAddingContact ? null : _toggleContact,
-                          label: _isFollow() ? 'Remove Contact' : 'Add Contact',
+                          onPressed: followState.isLoading ? null : _toggleFollow,
+                          loading: followState.isLoading,
+                          label: followState.isFollowing ? 'Unfollow' : 'Follow',
                           suffixIcon: SvgPicture.asset(
-                            _isFollow() ? AssetsPaths.icRemoveUser : AssetsPaths.icAddUser,
+                            followState.isFollowing
+                                ? AssetsPaths.icRemoveUser
+                                : AssetsPaths.icAddUser,
                             width: 18.w,
                             height: 18.w,
                             colorFilter: ColorFilter.mode(

--- a/test/ui/contact_list/start_chat_bottom_sheet_test.dart
+++ b/test/ui/contact_list/start_chat_bottom_sheet_test.dart
@@ -306,7 +306,6 @@ void main() {
       testWidgets('hides start chat option', (WidgetTester tester) async {
         await setup(tester);
         expect(find.text('Start Chat'), findsNothing);
-        expect(find.text('Invite to White Noise'), findsNothing);
       });
 
       testWidgets('hides add to group option', (WidgetTester tester) async {
@@ -314,9 +313,9 @@ void main() {
         expect(find.text('Add to Group'), findsNothing);
       });
 
-      testWidgets('hides invite option', (WidgetTester tester) async {
+      testWidgets('shows invite option', (WidgetTester tester) async {
         await setup(tester);
-        expect(find.text('Invite to White Noise'), findsNothing);
+        expect(find.text('Invite to White Noise'), findsOneWidget);
       });
     });
   });

--- a/test/ui/contact_list/start_chat_bottom_sheet_test.dart
+++ b/test/ui/contact_list/start_chat_bottom_sheet_test.dart
@@ -170,9 +170,9 @@ void main() {
         expect(find.text('Share'), findsOneWidget);
       });
 
-      testWidgets('hides add contact option', (WidgetTester tester) async {
+      testWidgets('hides follow option', (WidgetTester tester) async {
         await setup(tester);
-        expect(find.text('Add Contact'), findsNothing);
+        expect(find.text('Follow'), findsNothing);
       });
 
       testWidgets('hides add to group option', (WidgetTester tester) async {
@@ -207,9 +207,9 @@ void main() {
         expect(find.byType(CircularProgressIndicator), findsNothing);
       });
 
-      testWidgets('displays add contact option', (WidgetTester tester) async {
+      testWidgets('displays follow option', (WidgetTester tester) async {
         await setup(tester);
-        expect(find.text('Add Contact'), findsOneWidget);
+        expect(find.text('Follow'), findsOneWidget);
       });
 
       testWidgets('displays add to group option', (WidgetTester tester) async {
@@ -217,9 +217,9 @@ void main() {
         expect(find.text('Add to Group'), findsOneWidget);
       });
 
-      testWidgets('hides remove contact option', (WidgetTester tester) async {
+      testWidgets('hides unfollow option', (WidgetTester tester) async {
         await setup(tester);
-        expect(find.text('Remove Contact'), findsNothing);
+        expect(find.text('Unfollow'), findsNothing);
       });
 
       testWidgets('displays start chat option', (WidgetTester tester) async {
@@ -232,7 +232,7 @@ void main() {
         expect(find.text('Invite to White Noise'), findsNothing);
       });
 
-      group('when user is already a contact', () {
+      group('when user is already a follow', () {
         Future<void> setup(WidgetTester tester) async {
           await tester.pumpWidget(
             createTestWidget(
@@ -258,14 +258,14 @@ void main() {
           await tester.pumpAndSettle();
         }
 
-        testWidgets('displays remove contact option', (WidgetTester tester) async {
+        testWidgets('displays unfollow option', (WidgetTester tester) async {
           await setup(tester);
-          expect(find.text('Remove Contact'), findsOneWidget);
+          expect(find.text('Unfollow'), findsOneWidget);
         });
 
-        testWidgets('hides add contact option', (WidgetTester tester) async {
+        testWidgets('hides follow option', (WidgetTester tester) async {
           await setup(tester);
-          expect(find.text('Add Contact'), findsNothing);
+          expect(find.text('Follow'), findsNothing);
         });
 
         testWidgets('hides invite section', (WidgetTester tester) async {
@@ -293,14 +293,14 @@ void main() {
         await setup(tester);
         expect(find.byType(CircularProgressIndicator), findsNothing);
       });
-      testWidgets('hides add contact option', (WidgetTester tester) async {
+      testWidgets('hides follow option', (WidgetTester tester) async {
         await setup(tester);
-        expect(find.text('Add Contact'), findsNothing);
+        expect(find.text('Follow'), findsNothing);
       });
 
-      testWidgets('hides remove contact option', (WidgetTester tester) async {
+      testWidgets('hides unfollow option', (WidgetTester tester) async {
         await setup(tester);
-        expect(find.text('Remove Contact'), findsNothing);
+        expect(find.text('Unfollow'), findsNothing);
       });
 
       testWidgets('hides start chat option', (WidgetTester tester) async {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
This is a temporary workaround for https://github.com/parres-hq/whitenoise_flutter/issues/583 until the Rust crate is fixed to return None for pubkeys without a key package relay list (currently it throws an error).  Buut I don't like this approach cause it could hide other unexpected errors.  

I'm leaving this on draft now, just in case we want to release before the rust side is fixed. 
<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)
