### PR TITLE
explore: try to fix no account bug just by using active account provider

### DIFF
--- a/lib/ui/settings/general_settings_screen.dart
+++ b/lib/ui/settings/general_settings_screen.dart
@@ -126,7 +126,14 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
     );
   }
 
-  void _showAccountSwitcher({bool isDismissible = true, bool showSuccessToast = false}) {
+  Future<void> _showAccountSwitcher({
+    bool isDismissible = true,
+    bool showSuccessToast = false,
+  }) async {
+    if (_accounts.isEmpty) {
+      await _loadAccounts();
+    }
+
     final contactModels = _accounts.map(_accountToContactModel).toList();
 
     SwitchProfileBottomSheet.show(
@@ -249,7 +256,7 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
         await _loadAccounts();
 
         if (mounted) {
-          _showAccountSwitcher(isDismissible: false, showSuccessToast: true);
+          await _showAccountSwitcher(isDismissible: false, showSuccessToast: true);
         }
       } else {
         ref.showSuccessToast('Account signed out. Switched to the other available account.');
@@ -306,7 +313,7 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
                       label: 'Switch Account',
                       size: WnButtonSize.small,
                       visualState: WnButtonVisualState.secondary,
-                      onPressed: () => _showAccountSwitcher(),
+                      onPressed: () async => await _showAccountSwitcher(),
                       suffixIcon: WnImage(
                         AssetsPaths.icArrowsVertical,
 

--- a/lib/ui/settings/general_settings_screen.dart
+++ b/lib/ui/settings/general_settings_screen.dart
@@ -15,7 +15,6 @@ import 'package:whitenoise/domain/models/contact_model.dart';
 import 'package:whitenoise/domain/services/draft_message_service.dart';
 import 'package:whitenoise/routing/routes.dart';
 import 'package:whitenoise/src/rust/api/accounts.dart' show Account, getAccounts;
-import 'package:whitenoise/ui/contact_list/widgets/contact_list_tile.dart';
 import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
 import 'package:whitenoise/ui/core/ui/wn_app_bar.dart';
@@ -24,6 +23,7 @@ import 'package:whitenoise/ui/core/ui/wn_dialog.dart';
 import 'package:whitenoise/ui/core/ui/wn_image.dart';
 import 'package:whitenoise/ui/settings/developer/developer_settings_screen.dart';
 import 'package:whitenoise/ui/settings/profile/switch_profile_bottom_sheet.dart';
+import 'package:whitenoise/ui/settings/widgets/active_account_tile.dart';
 import 'package:whitenoise/utils/pubkey_formatter.dart';
 import 'package:whitenoise/utils/public_key_validation_extension.dart';
 
@@ -36,7 +36,6 @@ class GeneralSettingsScreen extends ConsumerStatefulWidget {
 
 class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
   List<Account> _accounts = [];
-  Account? _currentAccount;
   Map<String, ContactModel> _accountContactModels = {}; // Cache for contact models
   ProviderSubscription<AsyncValue<ActiveAccountState>>? _activeAccountSubscription;
   PackageInfo? _packageInfo;
@@ -73,12 +72,8 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
         contactModels[account.pubkey] = userProfileData;
       }
 
-      final activeAccountState = await ref.read(activeAccountProvider.future);
-      final activeAccount = activeAccountState.account;
-
       setState(() {
         _accounts = accounts;
-        _currentAccount = activeAccount;
         _accountContactModels = contactModels;
       });
     } catch (e) {
@@ -105,7 +100,6 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
       await ref.read(activePubkeyProvider.notifier).setActivePubkey(account.pubkey);
       await ref.read(followsProvider.notifier).loadFollows();
       await ref.read(groupsProvider.notifier).loadGroups();
-      setState(() => _currentAccount = account);
 
       if (mounted) {
         ref.showSuccessToast('Account switched successfully');
@@ -306,18 +300,7 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
                 padding: EdgeInsets.symmetric(horizontal: 16.w),
                 child: Column(
                   children: [
-                    if (_currentAccount != null)
-                      ContactListTile(
-                        contact: _accountToContactModel(_currentAccount!),
-                        trailingIcon: WnImage(
-                          AssetsPaths.icQrCode,
-                          size: 20.w,
-                          color: context.colors.primary,
-                        ),
-                        onTap: () => context.push('${Routes.settings}/share_profile'),
-                      )
-                    else
-                      const Center(child: Text('No accounts found')),
+                    const ActiveAccountTile(),
                     Gap(12.h),
                     WnFilledButton(
                       label: 'Switch Account',

--- a/lib/ui/settings/widgets/active_account_tile.dart
+++ b/lib/ui/settings/widgets/active_account_tile.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:go_router/go_router.dart';
+import 'package:whitenoise/config/providers/active_account_provider.dart';
+import 'package:whitenoise/domain/models/contact_model.dart';
+import 'package:whitenoise/routing/routes.dart';
+import 'package:whitenoise/ui/contact_list/widgets/contact_list_tile.dart';
+import 'package:whitenoise/ui/core/themes/assets.dart';
+import 'package:whitenoise/ui/core/themes/src/extensions.dart';
+import 'package:whitenoise/ui/core/ui/wn_image.dart';
+
+class ActiveAccountTile extends ConsumerWidget {
+  const ActiveAccountTile({super.key});
+
+  ContactModel _activeAccountToContactModel(ActiveAccountState state) {
+    return ContactModel.fromMetadata(
+      pubkey: state.account?.pubkey ?? '',
+      metadata: state.metadata,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final activeAccountState = ref.watch(activeAccountProvider);
+
+    return activeAccountState.when(
+      data: (state) {
+        if (state.account != null) {
+          return ContactListTile(
+            contact: _activeAccountToContactModel(state),
+            trailingIcon: WnImage(
+              AssetsPaths.icQrCode,
+              size: 20.w,
+              color: context.colors.primary,
+            ),
+            onTap: () => context.push('${Routes.settings}/share_profile'),
+          );
+        } else {
+          return const Center(child: Text('No accounts found'));
+        }
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, stack) => Center(child: Text('Error: $error')),
+    );
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Draft Pr, exploring a fix to no accounts bug without lazy loading accounts, jus changing to a widget that uses active account provider.

Edit: and loading accounts before rendering profile switch.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)
