### PR TITLE
Fix bubble tail order and padding

### DIFF
--- a/lib/ui/chat/widgets/message_widget.dart
+++ b/lib/ui/chat/widgets/message_widget.dart
@@ -45,7 +45,7 @@ class MessageWidget extends StatelessWidget {
         ChatMessageBubble(
           isSender: message.isMe,
           color: message.isMe ? context.colors.meChatBubble : context.colors.contactChatBubble,
-          tail: !isSameSenderAsNext,
+          tail: !isSameSenderAsPrevious,
           child: _buildMessageContent(context),
         ),
         if (message.reactions.isNotEmpty)
@@ -67,10 +67,8 @@ class MessageWidget extends StatelessWidget {
       onTap: onTap,
       child: Container(
         margin: EdgeInsets.only(
-          bottom:
-              message.reactions.isNotEmpty
-                  ? (isSameSenderAsPrevious ? 16.w : 24.w)
-                  : (isSameSenderAsPrevious ? 4.w : 12.w),
+          top: isSameSenderAsPrevious ? 4.w : 12.w,
+          bottom: message.reactions.isNotEmpty ? 12.w : 0,
         ),
         child: Row(
           mainAxisAlignment: message.isMe ? MainAxisAlignment.end : MainAxisAlignment.start,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
The chat bubble issues were fixed in message_widget.dart. The tail positioning was corrected from !isSameSenderAsNext to !isSameSenderAsPrevious, moving tails to the first message of each sender group. The spacing uses top margins (4.w for same sender, 12.w for different senders) and adds 12.w bottom margin when messages have reactions to provide extra spacing below reaction bubbles,

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)
