### PR TITLE
feat: add back buttons and update header styling in auth flow screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Global No relay indicator
 - [Android] Sensitive clipboard copy for private key (nsec).
 - Group info update functionality (name and description).
+- Add back buttons in auth flow screens for easier navigation.
 
 ### Changed
 

--- a/lib/ui/auth_flow/create_profile_screen.dart
+++ b/lib/ui/auth_flow/create_profile_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
 import 'package:whitenoise/config/providers/active_account_provider.dart';
 import 'package:whitenoise/config/providers/create_profile_screen_provider.dart';
 import 'package:whitenoise/ui/core/themes/assets.dart';
@@ -69,14 +70,27 @@ class _CreateProfileScreenState extends ConsumerState<CreateProfileScreen> {
           padding: EdgeInsets.fromLTRB(24.w, 32.h, 24.w, 0),
           child: Column(
             children: [
-              Text(
-                'Setup Profile',
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontSize: 32.sp,
-                  fontWeight: FontWeight.w700,
-                  color: context.colors.mutedForeground,
-                ),
+              Row(
+                children: [
+                  IconButton(
+                    onPressed: () => context.pop(),
+                    icon: WnImage(
+                      AssetsPaths.icChevronLeft,
+                      size: 18.w,
+                      color: context.colors.primary,
+                    ),
+                  ),
+                  Gap(8.w),
+                  Text(
+                    'Set Up Profile',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      fontSize: 18.sp,
+                      fontWeight: FontWeight.w600,
+                      color: context.colors.mutedForeground,
+                    ),
+                  ),
+                ],
               ),
               Gap(48.h),
               Stack(

--- a/lib/ui/auth_flow/info_screen.dart
+++ b/lib/ui/auth_flow/info_screen.dart
@@ -76,14 +76,27 @@ class _InfoScreenState extends ConsumerState<InfoScreen> {
               padding: const EdgeInsets.fromLTRB(24, 32, 24, 0).w,
               child: Column(
                 children: [
-                  Text(
-                    'Security Without\nCompromise',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      fontSize: 32.sp,
-                      fontWeight: FontWeight.w700,
-                      color: context.colors.mutedForeground,
-                    ),
+                  Row(
+                    children: [
+                      IconButton(
+                        onPressed: () => context.pop(),
+                        icon: WnImage(
+                          AssetsPaths.icChevronLeft,
+                          size: 18.w,
+                          color: context.colors.primary,
+                        ),
+                      ),
+                      Gap(8.w),
+                      Text(
+                        'Beyond the Noise',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 18.sp,
+                          fontWeight: FontWeight.w600,
+                          color: context.colors.mutedForeground,
+                        ),
+                      ),
+                    ],
                   ),
                   Gap(48.h),
                   FeatureItem(

--- a/lib/ui/auth_flow/login_screen.dart
+++ b/lib/ui/auth_flow/login_screen.dart
@@ -137,18 +137,31 @@ class _LoginScreenState extends ConsumerState<LoginScreen> with WidgetsBindingOb
                 children: [
                   Padding(
                     padding: EdgeInsets.only(top: 24.h),
-                    child: Text(
-                      'Login to White Noise',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontSize: 32.sp,
-                        fontWeight: FontWeight.w700,
-                        color: context.colors.mutedForeground,
-                      ),
-                      textHeightBehavior: const TextHeightBehavior(
-                        applyHeightToFirstAscent: false,
-                        applyHeightToLastDescent: false,
-                      ),
+                    child: Row(
+                      children: [
+                        IconButton(
+                          onPressed: () => context.pop(),
+                          icon: WnImage(
+                            AssetsPaths.icChevronLeft,
+                            size: 18.w,
+                            color: context.colors.primary,
+                          ),
+                        ),
+                        Gap(8.w),
+                        Text(
+                          'Login to White Noise',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            fontSize: 18.sp,
+                            fontWeight: FontWeight.w600,
+                            color: context.colors.mutedForeground,
+                          ),
+                          textHeightBehavior: const TextHeightBehavior(
+                            applyHeightToFirstAscent: false,
+                            applyHeightToLastDescent: false,
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                   Gap(79.5.h),


### PR DESCRIPTION
## Description

Fixes #364 

Back buttons are now added on the auth flow screens. This is to make it easier for devices that rely on gesture navigation (e.g iOS relying on the left swipe only).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [x] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)
