### PR TITLE
refactor: implement custom bottom sheet with fade animation and impro…

### DIFF
--- a/lib/ui/chat/services/chat_dialog_service.dart
+++ b/lib/ui/chat/services/chat_dialog_service.dart
@@ -10,6 +10,7 @@ import 'package:whitenoise/ui/chat/widgets/reaction/reaction_default_data.dart';
 import 'package:whitenoise/ui/chat/widgets/reaction/reaction_hero_dialog_route.dart';
 import 'package:whitenoise/ui/chat/widgets/reaction/reactions_dialog_widget.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
+import 'package:whitenoise/ui/core/ui/wn_bottom_sheet.dart';
 
 class ChatDialogService {
   static void showEmojiBottomSheet({
@@ -17,9 +18,10 @@ class ChatDialogService {
     required WidgetRef ref,
     required MessageModel message,
   }) {
-    showModalBottomSheet(
+    WnBottomSheet.show(
       context: context,
-      backgroundColor: Colors.transparent,
+      showCloseButton: false,
+      useSafeArea: false,
       builder: (context) {
         return Container(
           height: 0.4.sh,


### PR DESCRIPTION
## Description

Fixes #476 where the bottomSheets overlay slide up with the bottomSheets instead if fade in/out. Adds a private class (_FadeBottomSheetRoute) which is a custom page route with fade animation for the background overlay.


## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)
