### PR TITLE
Fix header on developer settings, fix padding on start new chat sheets

### DIFF
--- a/lib/ui/contact_list/new_chat_bottom_sheet.dart
+++ b/lib/ui/contact_list/new_chat_bottom_sheet.dart
@@ -323,6 +323,7 @@ class _NewChatBottomSheetState extends ConsumerState<NewChatBottomSheet> {
 
     return ListView.builder(
       controller: _scrollController,
+      padding: EdgeInsets.zero,
       itemCount: totalItems,
       itemBuilder: (context, index) {
         int currentIndex = 0;
@@ -517,23 +518,22 @@ class NewChatTile extends StatelessWidget {
             WnImage(
               iconPath,
               color: context.colors.primary,
-              size: 16.w,
+              size: 20.w,
             ),
-            Gap(10.w),
+            Gap(12.w),
             Text(
               title,
               style: TextStyle(
                 color: context.colors.primary,
-                fontSize: 14.sp,
-                fontWeight: FontWeight.w600,
+                fontSize: 16.sp,
               ),
             ),
-            Gap(8.w),
+            Gap(12.w),
             WnImage(
               AssetsPaths.icChevronRight,
               color: context.colors.primary,
-              width: 5.7.w,
-              height: 10.w,
+              width: 6.w,
+              height: 12.w,
             ),
           ],
         ),

--- a/lib/ui/contact_list/new_group_chat_sheet.dart
+++ b/lib/ui/contact_list/new_group_chat_sheet.dart
@@ -110,10 +110,7 @@ class _NewGroupChatSheetState extends ConsumerState<NewGroupChatSheet> {
     }
 
     return ListView.builder(
-      padding: EdgeInsets.symmetric(
-        horizontal: 16.w,
-        vertical: 8.h,
-      ),
+      padding: EdgeInsets.zero,
       itemCount: filteredContacts.length,
       itemBuilder: (context, index) {
         final contact = filteredContacts[index];

--- a/lib/ui/settings/developer/developer_settings_screen.dart
+++ b/lib/ui/settings/developer/developer_settings_screen.dart
@@ -3,11 +3,13 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
 import 'package:whitenoise/config/extensions/toast_extension.dart';
 import 'package:whitenoise/config/providers/active_pubkey_provider.dart';
 import 'package:whitenoise/src/rust/api/accounts.dart' as accounts_api;
 import 'package:whitenoise/ui/core/themes/assets.dart';
 import 'package:whitenoise/ui/core/themes/src/extensions.dart';
+import 'package:whitenoise/ui/core/ui/wn_app_bar.dart';
 import 'package:whitenoise/ui/core/ui/wn_button.dart';
 import 'package:whitenoise/ui/core/ui/wn_dialog.dart';
 import 'package:whitenoise/ui/core/ui/wn_image.dart';
@@ -232,153 +234,156 @@ class _DeveloperSettingsScreenState extends ConsumerState<DeveloperSettingsScree
       ),
       child: Scaffold(
         backgroundColor: context.colors.neutral,
+        appBar: WnAppBar(
+          automaticallyImplyLeading: false,
+          leading: RepaintBoundary(
+            child: IconButton(
+              onPressed: () => context.pop(),
+              icon: WnImage(
+                AssetsPaths.icChevronLeft,
+                width: 24.w,
+                height: 24.w,
+                color: context.colors.solidPrimary,
+              ),
+            ),
+          ),
+          title: RepaintBoundary(
+            child: Text(
+              'Developer Settings',
+              style: TextStyle(
+                fontSize: 18.sp,
+                fontWeight: FontWeight.w600,
+                color: context.colors.solidPrimary,
+              ),
+            ),
+          ),
+        ),
         body: SafeArea(
           bottom: false,
-          child: Column(
-            children: [
-              Gap(24.h),
-              RepaintBoundary(
-                child: Row(
-                  children: [
-                    IconButton(
-                      onPressed: () => Navigator.of(context).pop(),
-                      icon: WnImage(
-                        AssetsPaths.icChevronLeft,
-                        width: 24.w,
-                        height: 24.w,
-                        color: context.colors.primary,
-                      ),
-                    ),
-                    Text(
-                      'Developer Settings',
-                      style: TextStyle(
-                        fontSize: 18.sp,
-                        fontWeight: FontWeight.w600,
-                        color: context.colors.mutedForeground,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              Gap(29.h),
-              Expanded(
-                child: Padding(
-                  padding: EdgeInsets.only(
-                    left: 16.w,
-                    right: 16.w,
-                    bottom: 24.w,
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      RepaintBoundary(
+          child: ColoredBox(
+            color: context.colors.neutral,
+            child: Column(
+              children: [
+                Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(vertical: 24.h),
+                    child: SingleChildScrollView(
+                      child: Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 16.w),
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            // Key Package Management
-                            Text(
-                              'Key Package Management',
-                              style: TextStyle(
-                                fontSize: 14.sp,
-                                fontWeight: FontWeight.w600,
-                                color: context.colors.primary,
-                              ),
-                            ),
-                            Gap(10.h),
-                            WnFilledButton(
-                              label: 'Publish new key package',
-                              onPressed: _isLoading ? null : _publishKeyPackage,
-                              loading: _isLoading,
-                            ),
-                            Gap(8.h),
-                            WnFilledButton(
-                              label: 'Inspect relay key packages',
-                              onPressed: _isLoading ? null : _fetchKeyPackages,
-                              loading: _isLoading && !_showKeyPackages,
-                            ),
-                            Gap(8.h),
-                            WnFilledButton(
-                              label: 'Delete all key packages from relays',
-                              visualState: WnButtonVisualState.destructive,
-                              onPressed: _isLoading ? null : _deleteAllKeyPackages,
-                              loading: _isLoading && _showKeyPackages,
-                              labelTextStyle: WnButtonSize.large.textStyle().copyWith(
-                                color: context.colors.solidNeutralWhite,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      if (_showKeyPackages) ...[
-                        Gap(24.h),
-                        Text(
-                          'Key Packages (${_keyPackages.length})',
-                          style: TextStyle(
-                            fontSize: 16.sp,
-                            fontWeight: FontWeight.w600,
-                            color: context.colors.primary,
-                          ),
-                        ),
-                        Gap(12.h),
-                        if (_keyPackages.isEmpty)
-                          RepaintBoundary(
-                            child: Container(
-                              padding: EdgeInsets.all(16.w),
-                              decoration: BoxDecoration(
-                                color: context.colors.avatarSurface,
-
-                                borderRadius: BorderRadius.circular(8.r),
-                                border: Border.all(
-                                  color: context.colors.border.withValues(alpha: 0.3),
-                                  width: 0.5,
-                                ),
-                              ),
-                              child: Row(
+                            RepaintBoundary(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  WnImage(
-                                    AssetsPaths.icInformation,
-                                    size: 20.w,
-                                    color: context.colors.mutedForeground,
-                                  ),
-                                  SizedBox(width: 12.w),
+                                  // Key Package Management
                                   Text(
-                                    'No key packages found',
+                                    'Key Package Management',
                                     style: TextStyle(
                                       fontSize: 14.sp,
-                                      color: context.colors.mutedForeground,
+                                      fontWeight: FontWeight.w600,
+                                      color: context.colors.primary,
+                                    ),
+                                  ),
+                                  Gap(10.h),
+                                  WnFilledButton(
+                                    label: 'Publish new key package',
+                                    onPressed: _isLoading ? null : _publishKeyPackage,
+                                    loading: _isLoading,
+                                  ),
+                                  Gap(8.h),
+                                  WnFilledButton(
+                                    label: 'Inspect relay key packages',
+                                    onPressed: _isLoading ? null : _fetchKeyPackages,
+                                    loading: _isLoading && !_showKeyPackages,
+                                  ),
+                                  Gap(8.h),
+                                  WnFilledButton(
+                                    label: 'Delete all key packages from relays',
+                                    visualState: WnButtonVisualState.destructive,
+                                    onPressed: _isLoading ? null : _deleteAllKeyPackages,
+                                    loading: _isLoading && _showKeyPackages,
+                                    labelTextStyle: WnButtonSize.large.textStyle().copyWith(
+                                      color: context.colors.solidNeutralWhite,
                                     ),
                                   ),
                                 ],
                               ),
                             ),
-                          )
-                        else
-                          Expanded(
-                            child: RepaintBoundary(
-                              child: ListView.separated(
-                                itemCount: _keyPackages.length,
-                                separatorBuilder: (context, index) => SizedBox(height: 8.h),
-                                itemBuilder: (context, index) {
-                                  final keyPackage = _keyPackages[index];
-                                  return RepaintBoundary(
-                                    child: _KeyPackageItem(
-                                      keyPackage: keyPackage,
-                                      index: index,
-                                      isLoading: _isLoading,
-                                      onDelete: () => _deleteKeyPackage(keyPackage.id, index),
-                                    ),
-                                  );
-                                },
+                            if (_showKeyPackages) ...[
+                              Gap(24.h),
+                              Text(
+                                'Key Packages (${_keyPackages.length})',
+                                style: TextStyle(
+                                  fontSize: 16.sp,
+                                  fontWeight: FontWeight.w600,
+                                  color: context.colors.primary,
+                                ),
                               ),
-                            ),
-                          ),
-                      ],
-                      Gap(MediaQuery.of(context).padding.bottom),
-                    ],
+                              Gap(12.h),
+                              if (_keyPackages.isEmpty)
+                                RepaintBoundary(
+                                  child: Container(
+                                    padding: EdgeInsets.all(16.w),
+                                    decoration: BoxDecoration(
+                                      color: context.colors.avatarSurface,
+
+                                      borderRadius: BorderRadius.circular(8.r),
+                                      border: Border.all(
+                                        color: context.colors.border.withValues(alpha: 0.3),
+                                        width: 0.5,
+                                      ),
+                                    ),
+                                    child: Row(
+                                      children: [
+                                        WnImage(
+                                          AssetsPaths.icInformation,
+                                          size: 20.w,
+                                          color: context.colors.mutedForeground,
+                                        ),
+                                        SizedBox(width: 12.w),
+                                        Text(
+                                          'No key packages found',
+                                          style: TextStyle(
+                                            fontSize: 14.sp,
+                                            color: context.colors.mutedForeground,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                )
+                              else
+                                Expanded(
+                                  child: RepaintBoundary(
+                                    child: ListView.separated(
+                                      itemCount: _keyPackages.length,
+                                      separatorBuilder: (context, index) => SizedBox(height: 8.h),
+                                      itemBuilder: (context, index) {
+                                        final keyPackage = _keyPackages[index];
+                                        return RepaintBoundary(
+                                          child: _KeyPackageItem(
+                                            keyPackage: keyPackage,
+                                            index: index,
+                                            isLoading: _isLoading,
+                                            onDelete: () => _deleteKeyPackage(keyPackage.id, index),
+                                          ),
+                                        );
+                                      },
+                                    ),
+                                  ),
+                                ),
+                            ],
+                            Gap(MediaQuery.of(context).padding.bottom),
+                          ],
+                        ),
+                      ),
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
| Before | After |
| ---- | ---- |
| <img width="695" height="1255" alt="CleanShot 2025-09-22 at 22 06 35" src="https://github.com/user-attachments/assets/757095c2-a80c-4cb1-82db-985893ca5891" /> | <img width="646" height="1206" alt="CleanShot 2025-09-22 at 22 05 25" src="https://github.com/user-attachments/assets/a40a7fb1-84c4-4136-807a-776df145289a" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Developer Settings: persistent Key Package Management header with Publish/Inspect/Delete action buttons and per-action loading states.

- Refactor
  - Developer Settings redesigned with a custom app bar, scrollable layout, and clearer presentation of key packages including bordered item containers and integrated confirmation flows.

- Style
  - New Chat and Group Chat lists: removed list padding for a tighter layout; increased icon/text sizes, adjusted spacing and chevron size for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->