### PR TITLE
Fix for Kt version warning during Android build.

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include(":app")


### PR DESCRIPTION
## Description

Fixes #695 where we have warning on the project's Kotlin going out of date soon.

### Changes

Updated the project's Kotlin Android plugin from 1.8.22 to 2.2.20 (latest).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the Kotlin Android Gradle plugin to a newer major version to align with current Android/Kotlin tooling.
  * Improves build stability, compatibility with recent Android Studio/Kotlin releases, and may deliver faster builds.
  * Reduces deprecation warnings during builds and modernizes the project configuration.
  * No changes to app functionality; end-user experience remains unchanged.
  * If build issues occur after updating, re-sync the project and clear Gradle caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->