### PR TITLE
Add haptic feedback on tap down before context menu is shown

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -94,23 +94,23 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
 
 SPEC CHECKSUMS:
-  audio_session: 19e9480dbdd4e5f6c4543826b2e8b0e4ab6145fe
-  emoji_picker_flutter: 8e50ec5caac456a23a78637e02c6293ea0ac8771
+  audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
+  emoji_picker_flutter: ece213fc274bdddefb77d502d33080dc54e616cc
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_local_notifications: df98d66e515e1ca797af436137b4459b160ad8c9
-  flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
-  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  flutter_timezone: ac3da59ac941ff1c98a2e1f0293420e020120282
-  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
-  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  just_audio: a42c63806f16995daf5b219ae1d679deb76e6a79
-  mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  rust_lib_whitenoise: 69ef24b69b2aba78a7ebabc09a504b5a39177d21
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  flutter_local_notifications: 395056b3175ba4f08480a7c5de30cd36d69827e4
+  flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
+  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
+  flutter_timezone: 7c838e17ffd4645d261e87037e5bebf6d38fe544
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
+  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
+  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  rust_lib_whitenoise: 22de658398f8e36a1a396d35b6b6547a0732e6bb
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
 
 PODFILE CHECKSUM: 251cb053df7158f337c0712f2ab29f4e0fa474ce
 

--- a/lib/ui/chat/services/chat_dialog_service.dart
+++ b/lib/ui/chat/services/chat_dialog_service.dart
@@ -90,7 +90,6 @@ class ChatDialogService {
     required int messageIndex,
   }) {
     final chatNotifier = ref.read(chatProvider.notifier);
-    HapticFeedback.mediumImpact();
 
     Navigator.of(context).push(
       HeroDialogRoute(

--- a/lib/ui/chat/services/chat_dialog_service.dart
+++ b/lib/ui/chat/services/chat_dialog_service.dart
@@ -1,6 +1,5 @@
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:whitenoise/config/providers/chat_provider.dart';

--- a/lib/ui/chat/widgets/swipe_to_reply_widget.dart
+++ b/lib/ui/chat/widgets/swipe_to_reply_widget.dart
@@ -35,9 +35,11 @@ class _SwipeToReplyWidgetState extends State<SwipeToReplyWidget> {
   bool _hapticTriggered = false;
   bool _canUndo = false;
   Timer? _longPressTimer;
+  Timer? _longPressHapticTimer;
 
   void _handleDragStart(DragStartDetails details) {
     _longPressTimer?.cancel();
+    _longPressHapticTimer?.cancel();
     setState(() {
       _showReplyIcon = true;
       _canUndo = false;
@@ -83,22 +85,33 @@ class _SwipeToReplyWidgetState extends State<SwipeToReplyWidget> {
   }
 
   void _onTapDown(TapDownDetails details) {
-    _longPressTimer = Timer(const Duration(milliseconds: 200), () {
+    _longPressTimer?.cancel();
+    _longPressHapticTimer?.cancel();
+
+    _longPressHapticTimer = Timer(const Duration(milliseconds: 100), () {
+      HapticFeedback.mediumImpact();
+    });
+
+    _longPressTimer = Timer(const Duration(milliseconds: 250), () {
+      _longPressHapticTimer?.cancel();
       widget.onLongPress();
     });
   }
 
   void _onTapUp(TapUpDetails details) {
     _longPressTimer?.cancel();
+    _longPressHapticTimer?.cancel();
   }
 
   void _onTapCancel() {
     _longPressTimer?.cancel();
+    _longPressHapticTimer?.cancel();
   }
 
   @override
   void dispose() {
     _longPressTimer?.cancel();
+    _longPressHapticTimer?.cancel();
     super.dispose();
   }
 


### PR DESCRIPTION
## Description

Fixes #479 

### Summary
- **Fix haptic timing for long-press** by firing a short-delay pulse inside lib/ui/chat/widgets/swipe_to_reply_widget.dart, so users feel feedback ~100 ms after pressing, well before the context menu appears at 250 ms.
- **Remove redundant vibration** in lib/ui/chat/services/chat_dialog_service.dart to avoid a second pulse when the context menu opens.

### Why
- **Issue**: Chats only vibrated when the context menu popped up, violating the UX request (“Right now in chats, haptic feedback is activated at the same time the context menu is shown. It should activate earlier…”).
- **Impact**: Users had no physical hint that a menu was pending; the single haptic happened too late to guide the hold action.
- **Fix**: Trigger a dedicated haptic shortly after touch-down and lengthen the long-press window a little bit, while removing the late pulse in the dialog service.

### Benefits
- **Earlier tactile cue** that a hold will open the menu.
- **Cleaner feedback** by keeping the vibration tied only to the pre-menu hint.
- **Consistent UX** across message interactions.

#### Files Changed
- [lib/ui/chat/widgets/swipe_to_reply_widget.dart](cci:7://file:///Users/quwaysim/Development/codebases/whitenoise_flutter/lib/ui/chat/widgets/swipe_to_reply_widget.dart:0:0-0:0)
- [lib/ui/chat/services/chat_dialog_service.dart](cci:7://file:///Users/quwaysim/Development/codebases/whitenoise_flutter/lib/ui/chat/services/chat_dialog_service.dart:0:0-0:0)

# Tested on
- Android
- GrapheneOS

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [x] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [x] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)
