### PR TITLE
fix: translate unknown user everywhere

### DIFF
--- a/lib/config/providers/group_provider.dart
+++ b/lib/config/providers/group_provider.dart
@@ -14,6 +14,7 @@ import 'package:whitenoise/src/rust/api/error.dart' show ApiError;
 import 'package:whitenoise/src/rust/api/groups.dart';
 import 'package:whitenoise/src/rust/api/users.dart' as rust_users;
 import 'package:whitenoise/utils/error_handling.dart';
+import 'package:whitenoise/utils/localization_extensions.dart';
 import 'package:whitenoise/utils/pubkey_formatter.dart';
 
 PubkeyFormatter _defaultPubkeyFormatter({String? pubkey}) => PubkeyFormatter(pubkey: pubkey);
@@ -393,7 +394,7 @@ class GroupsNotifier extends Notifier<GroupsState> {
             // Create a fallback user with minimal info
             final fallbackUser = domain_user.User(
               id: npub,
-              displayName: 'Unknown User',
+              displayName: 'shared.unknownUser'.tr(),
               nip05: '',
               publicKey: npub,
             );
@@ -474,7 +475,7 @@ class GroupsNotifier extends Notifier<GroupsState> {
             // Create a fallback user with minimal info
             final fallbackUser = domain_user.User(
               id: npub,
-              displayName: 'Unknown User',
+              displayName: 'shared.unknownUser'.tr(),
               nip05: '',
               publicKey: npub,
             );
@@ -677,7 +678,9 @@ class GroupsNotifier extends Notifier<GroupsState> {
           return 'Direct Message';
         }
 
-        return otherMember.displayName.isNotEmpty ? otherMember.displayName : 'Unknown User';
+        return otherMember.displayName.isNotEmpty
+            ? otherMember.displayName
+            : 'shared.unknownUser'.tr();
       } catch (e) {
         String logMessage =
             'Failed to get other member name for DM group ${group.mlsGroupId} - Exception: ';

--- a/lib/domain/models/user_profile.dart
+++ b/lib/domain/models/user_profile.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:whitenoise/src/rust/api/metadata.dart' show FlutterMetadata;
+import 'package:whitenoise/utils/localization_extensions.dart';
 import 'package:whitenoise/utils/pubkey_formatter.dart';
 import 'package:whitenoise/utils/string_extensions.dart';
 
@@ -54,7 +55,7 @@ class UserProfile {
     final npub = PubkeyFormatter(pubkey: pubkey).toNpub() ?? '';
 
     // Use display_name first, then fall back to name, then to Unknown User
-    String finalDisplayName = 'Unknown User';
+    String finalDisplayName = 'shared.unknownUser'.tr();
     if (displayName.isNotEmpty) {
       finalDisplayName = displayName;
     } else if (name.isNotEmpty) {

--- a/lib/locales/de.json
+++ b/lib/locales/de.json
@@ -12,7 +12,8 @@
         "discardChanges": "Änderungen verwerfen",
         "unsavedChanges": "Nicht gespeicherte Änderungen",
         "continue": "Fortfahren",
-        "system": "System"
+        "system": "System",
+        "unknownUser": "Unbekannter Benutzer"
     },
     "settings": {
         "title": "Einstellungen",
@@ -163,7 +164,6 @@
         "inviteShareFailed": "Einladung konnte nicht geteilt werden",
         "sharing": "Wird geteilt...",
         "share": "Teilen",
-        "unknownUser": "Unbekannter Benutzer",
         "thisUser": "Dieser Benutzer",
         "inviteToWhiteNoise": "Zu White Noise einladen",
         "userNotOnWhiteNoise": "{userProfileName} ist noch nicht bei White Noise. Teilen Sie den Download-Link, um einen sicheren Chat zu starten.",

--- a/lib/locales/en.json
+++ b/lib/locales/en.json
@@ -12,7 +12,8 @@
         "discardChanges": "Discard Changes",
         "unsavedChanges": "Unsaved changes",
         "continue": "Continue",
-        "system": "System"
+        "system": "System",
+        "unknownUser": "Unknown User"
     },
     "settings": {
         "title": "Settings",
@@ -163,7 +164,6 @@
         "inviteShareFailed": "Failed to share invite",
         "sharing": "Sharing...",
         "share": "Share",
-        "unknownUser": "Unknown User",
         "thisUser": "This user",
         "inviteToWhiteNoise": "Invite to White Noise",
         "userNotOnWhiteNoise": "{userName} isn't on White Noise yet. Share the download link to start a secure chat.",

--- a/lib/locales/es.json
+++ b/lib/locales/es.json
@@ -12,7 +12,8 @@
         "discardChanges": "Descartar cambios",
         "unsavedChanges": "Cambios sin guardar",
         "continue": "Continuar",
-        "system": "Sistema"
+        "system": "Sistema",
+        "unknownUser": "Usuario desconocido"
     },
     "settings": {
         "title": "Configuración",
@@ -163,7 +164,6 @@
         "inviteShareFailed": "Error al compartir invitación",
         "sharing": "Compartiendo...",
         "share": "Compartir",
-        "unknownUser": "Usuario desconocido",
         "thisUser": "Este usuario",
         "inviteToWhiteNoise": "Invitar a White Noise",
         "userNotOnWhiteNoise": "{userName} aún no está en White Noise. Comparte el enlace de descarga para iniciar un chat seguro.",

--- a/lib/locales/fr.json
+++ b/lib/locales/fr.json
@@ -12,7 +12,8 @@
         "discardChanges": "Ignorer les changements",
         "unsavedChanges": "Changements non sauvegardés",
         "continue": "Continuer",
-        "system": "Système"
+        "system": "Système",
+        "unknownUser": "Utilisateur inconnu"
     },
     "settings": {
         "title": "Paramètres",
@@ -163,7 +164,6 @@
         "inviteShareFailed": "Échec du partage de l'invitation",
         "sharing": "Partage...",
         "share": "Partager",
-        "unknownUser": "Utilisateur inconnu",
         "thisUser": "Cet utilisateur",
         "inviteToWhiteNoise": "Inviter à White Noise",
         "userNotOnWhiteNoise": "{userName} n'est pas encore sur White Noise. Partagez le lien de téléchargement pour commencer une conversation sécurisée.",

--- a/lib/locales/it.json
+++ b/lib/locales/it.json
@@ -12,7 +12,8 @@
         "discardChanges": "Scarta modifiche",
         "unsavedChanges": "Modifiche non salvate",
         "continue": "Continua",
-        "system": "Sistema"
+        "system": "Sistema",
+        "unknownUser": "Utente sconosciuto"
     },
     "settings": {
         "title": "Impostazioni",
@@ -163,7 +164,6 @@
         "inviteShareFailed": "Impossibile condividere l'invito",
         "sharing": "Condivisione...",
         "share": "Condividi",
-        "unknownUser": "Utente sconosciuto",
         "thisUser": "Questo utente",
         "inviteToWhiteNoise": "Invita a White Noise",
         "userNotOnWhiteNoise": "{userName} non è ancora su White Noise. Condividi il link di download per iniziare una chat sicura.",

--- a/lib/locales/pt.json
+++ b/lib/locales/pt.json
@@ -12,7 +12,8 @@
         "discardChanges": "Descartar alterações",
         "unsavedChanges": "Alterações não salvas",
         "continue": "Continuar",
-        "system": "Sistema"
+        "system": "Sistema",
+        "unknownUser": "Usuário desconhecido"
     },
     "settings": {
         "title": "Configurações",
@@ -163,7 +164,6 @@
         "inviteShareFailed": "Falha ao compartilhar convite",
         "sharing": "Compartilhando...",
         "share": "Compartilhar",
-        "unknownUser": "Usuário desconhecido",
         "thisUser": "Este usuário",
         "inviteToWhiteNoise": "Convidar para o White Noise",
         "userNotOnWhiteNoise": "{userName} ainda não está no White Noise. Compartilhe o link de download para iniciar uma conversa segura.",

--- a/lib/locales/ru.json
+++ b/lib/locales/ru.json
@@ -12,7 +12,8 @@
         "discardChanges": "Отменить изменения",
         "unsavedChanges": "Несохранённые изменения",
         "continue": "Продолжить",
-        "system": "Система"
+        "system": "Система",
+        "unknownUser": "Неизвестный пользователь"
     },
     "settings": {
         "title": "Настройки",
@@ -163,7 +164,6 @@
         "inviteShareFailed": "Не удалось поделиться приглашением",
         "sharing": "Отправка...",
         "share": "Поделиться",
-        "unknownUser": "Неизвестный пользователь",
         "thisUser": "Этот пользователь",
         "inviteToWhiteNoise": "Пригласить в White Noise",
         "userNotOnWhiteNoise": "{userName} ещё нет в White Noise. Поделитесь ссылкой для скачивания, чтобы начать безопасный чат.",

--- a/lib/locales/tr.json
+++ b/lib/locales/tr.json
@@ -12,7 +12,8 @@
         "discardChanges": "Değişiklikleri İptal Et",
         "unsavedChanges": "Kaydedilmemiş değişiklikler",
         "continue": "Devam Et",
-        "system": "Sistem"
+        "system": "Sistem",
+        "unknownUser": "Bilinmeyen Kullanıcı"
     },
     "settings": {
         "title": "Ayarlar",
@@ -163,7 +164,6 @@
         "inviteShareFailed": "Davet paylaşma başarısız",
         "sharing": "Paylaşılıyor...",
         "share": "Paylaş",
-        "unknownUser": "Bilinmeyen Kullanıcı",
         "thisUser": "Bu kullanıcı",
         "inviteToWhiteNoise": "White Noise'a Davet Et",
         "userNotOnWhiteNoise": "{userName} henüz White Noise'de değil. Güvenli bir sohbet başlatmak için indirme bağlantısını paylaşın.",

--- a/lib/ui/chat/chat_management/add_to_group_screen.dart
+++ b/lib/ui/chat/chat_management/add_to_group_screen.dart
@@ -15,6 +15,7 @@ import 'package:whitenoise/ui/core/ui/wn_bottom_fade.dart';
 import 'package:whitenoise/ui/core/ui/wn_button.dart';
 import 'package:whitenoise/ui/core/ui/wn_image.dart';
 import 'package:whitenoise/ui/user_profile_list/new_group_chat_sheet.dart';
+import 'package:whitenoise/utils/localization_extensions.dart';
 import 'package:whitenoise/utils/pubkey_formatter.dart';
 
 class AddToGroupScreen extends ConsumerStatefulWidget {
@@ -162,7 +163,7 @@ class _AddToGroupScreenState extends ConsumerState<AddToGroupScreen> {
           } catch (e) {
             // Create a basic user profile with just the public key
             userProfileToAdd = UserProfile(
-              displayName: 'Unknown User',
+              displayName: 'shared.unknownUser'.tr(),
               publicKey: widget.userNpub,
             );
           }

--- a/lib/ui/chat/invite/chat_invite_screen.dart
+++ b/lib/ui/chat/invite/chat_invite_screen.dart
@@ -248,7 +248,7 @@ class DMInviteHeader extends ConsumerWidget {
       future: userProfileNotifier.getUserProfile(welcome.welcomer),
       builder: (context, snapshot) {
         final welcomerUser = snapshot.data;
-        final welcomerName = welcomerUser?.displayName ?? 'Unknown User';
+        final welcomerName = welcomerUser?.displayName ?? 'shared.unknownUser'.tr();
         final welcomerImageUrl = welcomerUser?.imagePath ?? '';
 
         return Container(
@@ -342,7 +342,7 @@ class DMAppBarTitle extends ConsumerWidget {
         }
 
         final welcomerUser = snapshot.data;
-        final welcomerName = welcomerUser?.displayName ?? 'Unknown User';
+        final welcomerName = welcomerUser?.displayName ?? 'shared.unknownUser'.tr();
         final welcomerImageUrl = welcomerUser?.imagePath ?? '';
 
         return UserProfileInfo(

--- a/lib/ui/user_profile_list/group_welcome_invitation_sheet.dart
+++ b/lib/ui/user_profile_list/group_welcome_invitation_sheet.dart
@@ -11,6 +11,7 @@ import 'package:whitenoise/ui/core/themes/src/extensions.dart';
 import 'package:whitenoise/ui/core/ui/wn_avatar.dart';
 import 'package:whitenoise/ui/core/ui/wn_bottom_sheet.dart';
 import 'package:whitenoise/ui/core/ui/wn_button.dart';
+import 'package:whitenoise/utils/localization_extensions.dart';
 import 'package:whitenoise/utils/pubkey_formatter.dart';
 import 'package:whitenoise/utils/string_extensions.dart';
 
@@ -183,7 +184,7 @@ class _GroupMessageInviteState extends ConsumerState<GroupMessageInvite> {
               future: _fetchInviterMetadata(),
               builder: (context, snapshot) {
                 final displayName =
-                    snapshot.data?.displayName ?? snapshot.data?.name ?? 'Unknown User';
+                    snapshot.data?.displayName ?? snapshot.data?.name ?? 'shared.unknownUser'.tr();
                 return Row(
                   children: [
                     WnAvatar(
@@ -340,7 +341,7 @@ class _DirectMessageInviteCardState extends ConsumerState<DirectMessageInviteCar
         return Column(
           children: [
             Text(
-              displayName ?? 'Unknown User',
+              displayName ?? 'shared.unknownUser'.tr(),
               textAlign: TextAlign.center,
               style: TextStyle(
                 fontSize: 18.sp,

--- a/lib/ui/user_profile_list/widgets/share_invite_callout.dart
+++ b/lib/ui/user_profile_list/widgets/share_invite_callout.dart
@@ -14,7 +14,7 @@ class ShareInviteCallout extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final userName =
-        userProfile.displayName.isNotEmpty && userProfile.displayName != 'Unknown User'
+        userProfile.displayName.isNotEmpty && userProfile.displayName != 'shared.unknownUser'.tr()
             ? userProfile.displayName
             : 'chats.thisUser'.tr();
     final inviteMessage = 'chats.userNotOnWhiteNoise'.tr({'userName': userName});

--- a/lib/utils/message_converter.dart
+++ b/lib/utils/message_converter.dart
@@ -1,6 +1,7 @@
 import 'package:whitenoise/domain/models/message_model.dart';
 import 'package:whitenoise/domain/models/user_model.dart' as domain_user;
 import 'package:whitenoise/src/rust/api/messages.dart';
+import 'package:whitenoise/utils/localization_extensions.dart';
 import 'package:whitenoise/utils/pubkey_utils.dart';
 import 'package:whitenoise/utils/reaction_converter.dart';
 
@@ -133,7 +134,7 @@ class MessageConverter {
   static domain_user.User _unknownUser({required String pubkey}) {
     return domain_user.User(
       id: pubkey,
-      displayName: 'Unknown User',
+      displayName: 'shared.unknownUser'.tr(),
       nip05: '',
       publicKey: pubkey,
     );
@@ -216,7 +217,7 @@ class MessageConverter {
       createdAt: DateTime.now(),
       sender: domain_user.User(
         id: 'unknown',
-        displayName: 'Unknown User',
+        displayName: 'shared.unknownUser'.tr(),
         nip05: '',
         publicKey: 'unknown',
       ),

--- a/lib/utils/reaction_converter.dart
+++ b/lib/utils/reaction_converter.dart
@@ -1,6 +1,7 @@
 import 'package:whitenoise/domain/models/message_model.dart';
 import 'package:whitenoise/domain/models/user_model.dart' as domain_user;
 import 'package:whitenoise/src/rust/api/messages.dart';
+import 'package:whitenoise/utils/localization_extensions.dart';
 
 /// Converts ReactionSummary to Reaction list
 class ReactionConverter {
@@ -15,7 +16,7 @@ class ReactionConverter {
           usersMap[userReaction.user] ??
           domain_user.User(
             id: userReaction.user,
-            displayName: 'Unknown User',
+            displayName: 'shared.unknownUser'.tr(),
             nip05: '',
             publicKey: userReaction.user,
           );

--- a/lib/utils/user_utils.dart
+++ b/lib/utils/user_utils.dart
@@ -1,4 +1,5 @@
 import 'package:whitenoise/src/rust/api/users.dart';
+import 'package:whitenoise/utils/localization_extensions.dart';
 
 /// Utility class for User operations like sorting and filtering
 class UserUtils {
@@ -9,9 +10,9 @@ class UserUtils {
       final aName = _getDisplayName(a);
       final bName = _getDisplayName(b);
 
-      if (aName == 'Unknown User' && bName != 'Unknown User') return 1;
-      if (bName == 'Unknown User' && aName != 'Unknown User') return -1;
-      if (aName == 'Unknown User' && bName == 'Unknown User') return 0;
+      if (aName == 'shared.unknownUser'.tr() && bName != 'shared.unknownUser'.tr()) return 1;
+      if (bName == 'shared.unknownUser'.tr() && aName != 'shared.unknownUser'.tr()) return -1;
+      if (aName == 'shared.unknownUser'.tr() && bName == 'shared.unknownUser'.tr()) return 0;
 
       return aName.toLowerCase().compareTo(bName.toLowerCase());
     });
@@ -62,7 +63,7 @@ class UserUtils {
       return metadata.name!;
     }
 
-    return 'Unknown User';
+    return 'shared.unknownUser'.tr();
   }
 
   static String getDisplayName(User user) {

--- a/test/config/providers/group_messages_provider_test.dart
+++ b/test/config/providers/group_messages_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:whitenoise/config/providers/group_messages_provider.dart';
 import 'package:whitenoise/config/providers/user_profile_provider.dart';
 import 'package:whitenoise/domain/models/user_profile.dart';
 import 'package:whitenoise/src/rust/api/messages.dart';
+import 'package:whitenoise/utils/localization_extensions.dart';
 import 'package:whitenoise/utils/pubkey_formatter.dart';
 
 class MockActivePubkeyNotifier extends ActivePubkeyNotifier {
@@ -27,7 +28,7 @@ class MockUserProfileNotifier extends UserProfileNotifier {
     return _userProfiles[pubkey] ??
         UserProfile(
           publicKey: pubkey,
-          displayName: 'Unknown User',
+          displayName: 'shared.unknownUser'.tr(),
         );
   }
 }

--- a/test/config/providers/user_profile_provider_test.dart
+++ b/test/config/providers/user_profile_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:whitenoise/config/providers/user_profile_provider.dart';
 import 'package:whitenoise/domain/models/user_profile.dart';
 import 'package:whitenoise/src/rust/api/metadata.dart' show FlutterMetadata;
 import 'package:whitenoise/src/rust/api/users.dart';
+import 'package:whitenoise/utils/localization_extensions.dart';
 
 final testNpubPubkey = 'npub1zygjyg3nxdzyg424ven8waug3zvejqqq424thw7venwammhwlllsj2q4yf';
 final testHexPubkey = '1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff';
@@ -156,12 +157,12 @@ void main() {
 
         group('with npub pubkey', () {
           test(
-            'returns data with "Unknown User" for display name',
+            'returns data with Unknown User for display name',
             () async {
               final notifier = container.read(userProfileProvider.notifier);
               final result = await notifier.getUserProfile(testNpubPubkey);
               expect(result, isNotNull);
-              expect(result.displayName, 'Unknown User');
+              expect(result.displayName, 'shared.unknownUser'.tr());
               expect(result.about, 'Bio without name');
             },
           );
@@ -174,7 +175,7 @@ void main() {
               final notifier = container.read(userProfileProvider.notifier);
               final result = await notifier.getUserProfile(testHexPubkey);
               expect(result, isNotNull);
-              expect(result.displayName, 'Unknown User');
+              expect(result.displayName, 'shared.unknownUser'.tr());
               expect(result.about, 'Bio without name');
             },
           );

--- a/test/ui/contact_list/widgets/share_invite_callout_test.dart
+++ b/test/ui/contact_list/widgets/share_invite_callout_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:whitenoise/domain/models/user_profile.dart';
 import 'package:whitenoise/ui/user_profile_list/widgets/share_invite_callout.dart';
+import 'package:whitenoise/utils/localization_extensions.dart';
 import '../../../test_helpers.dart';
 
 void main() {
@@ -27,7 +28,7 @@ void main() {
 
     group('when userProfile has an unknown display name', () {
       final userProfile = UserProfile(
-        displayName: 'Unknown User',
+        displayName: 'shared.unknownUser'.tr(),
         publicKey: 'abc123def456789012345678901234567890123456789012345678901234567890',
         nip05: 'satoshi@nakamoto.com',
         imagePath: 'https://example.com/satoshi.png',

--- a/test/utils/message_converter_test.dart
+++ b/test/utils/message_converter_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:whitenoise/domain/models/message_model.dart';
 import 'package:whitenoise/domain/models/user_model.dart' as domain_user;
 import 'package:whitenoise/src/rust/api/messages.dart';
+import 'package:whitenoise/utils/localization_extensions.dart';
 import 'package:whitenoise/utils/message_converter.dart';
 
 bool mockPubkeyUtilsIsMe({required String myPubkey, required String otherPubkey}) {
@@ -128,7 +129,7 @@ void main() {
           );
 
           expect(result.sender.id, unknownUserPubkey);
-          expect(result.sender.displayName, 'Unknown User');
+          expect(result.sender.displayName, 'shared.unknownUser'.tr());
           expect(result.sender.nip05, '');
           expect(result.sender.publicKey, unknownUserPubkey);
         });

--- a/test/utils/reaction_converter_test.dart
+++ b/test/utils/reaction_converter_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:whitenoise/domain/models/message_model.dart' show Reaction;
 import 'package:whitenoise/domain/models/user_model.dart' as domain_user;
 import 'package:whitenoise/src/rust/api/messages.dart';
+import 'package:whitenoise/utils/localization_extensions.dart';
 import 'package:whitenoise/utils/reaction_converter.dart';
 
 void main() {
@@ -93,7 +94,7 @@ void main() {
           final secondReactionUser = secondReaction.user;
           expect(secondReactionUser, isA<domain_user.User>());
           expect(secondReactionUser.id, 'npub1_nice_jane_456');
-          expect(secondReactionUser.displayName, 'Unknown User');
+          expect(secondReactionUser.displayName, 'shared.unknownUser'.tr());
           expect(secondReactionUser.nip05, '');
           expect(secondReactionUser.publicKey, 'npub1_nice_jane_456');
         });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
This PR fixes #725 by translating the "Unknown User" where translations were missing. The key was already present under chats but unused in some parts. I moved it to the shared key in locales cause it's used in lots of screens

|Before|After|
|----|----|
|![unknown -user-bug](https://github.com/user-attachments/assets/86b779f7-969f-4605-bcb9-9a25f7e4b7fe)|![translated-unknown-user](https://github.com/user-attachments/assets/88c89b14-49e4-4b96-8c95-d8f20cc89034)|



<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized fallback for unknown user names across the app (DMs, group members/admins, invites, reactions, replies, lists, and profile displays).
  * Added translations for the unknown user label in EN, DE, ES, FR, IT, PT, RU, and TR under a shared key.
* **Bug Fixes**
  * Ensures consistent, language-aware display when a user’s name is missing, replacing hardcoded English text.
* **Tests**
  * Updated tests to assert against the localized unknown user label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->