### PR TITLE
refactor: move repeated mock in tests to its own mock file

### DIFF
--- a/test/config/providers/active_account_provider_test.dart
+++ b/test/config/providers/active_account_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:whitenoise/config/providers/active_account_provider.dart';
 import 'package:whitenoise/config/providers/active_pubkey_provider.dart';
 import 'package:whitenoise/src/rust/api/accounts.dart' as accounts_api show Account;
 import 'package:whitenoise/src/rust/api/metadata.dart' show FlutterMetadata;
+import '../../shared/mocks/mock_active_pubkey_notifier.dart';
 
 class MockWnImageUtils implements WnImageUtils {
   String? _mimeType = 'image/jpeg';
@@ -121,23 +122,6 @@ class MockWnAccountsApi implements WnAccountsApi {
     }
 
     return 'https://example.com/profile-pictures/$pubkey.jpg';
-  }
-}
-
-class MockActivePubkeyNotifier extends ActivePubkeyNotifier {
-  String? _pubkey;
-
-  MockActivePubkeyNotifier(this._pubkey);
-
-  @override
-  String? build() {
-    return _pubkey;
-  }
-
-  @override
-  Future<void> setActivePubkey(String pubkey) async {
-    _pubkey = pubkey;
-    state = pubkey;
   }
 }
 

--- a/test/config/providers/group_messages_provider_test.dart
+++ b/test/config/providers/group_messages_provider_test.dart
@@ -7,15 +7,7 @@ import 'package:whitenoise/domain/models/user_profile.dart';
 import 'package:whitenoise/src/rust/api/messages.dart';
 import 'package:whitenoise/utils/localization_extensions.dart';
 import 'package:whitenoise/utils/pubkey_formatter.dart';
-
-class MockActivePubkeyNotifier extends ActivePubkeyNotifier {
-  final String? _pubkey;
-
-  MockActivePubkeyNotifier(this._pubkey) : super(storage: null, pubkeyFormatter: null);
-
-  @override
-  String? build() => _pubkey;
-}
+import '../../shared/mocks/mock_active_pubkey_notifier.dart';
 
 class MockUserProfileNotifier extends UserProfileNotifier {
   final Map<String, UserProfile> _userProfiles;

--- a/test/config/providers/group_provider_test.dart
+++ b/test/config/providers/group_provider_test.dart
@@ -9,19 +9,9 @@ import 'package:whitenoise/config/states/auth_state.dart';
 import 'package:whitenoise/domain/models/user_model.dart';
 import 'package:whitenoise/src/rust/api/groups.dart';
 import 'package:whitenoise/utils/pubkey_formatter.dart';
+import '../../shared/mocks/mock_active_pubkey_notifier.dart';
 
 import 'group_provider_test.mocks.dart';
-
-class MockActivePubkeyNotifier extends ActivePubkeyNotifier {
-  final String? _mockValue;
-
-  MockActivePubkeyNotifier(this._mockValue);
-
-  @override
-  String? build() {
-    return _mockValue;
-  }
-}
 
 class MockAuthNotifier extends AuthNotifier {
   final AuthState _mockState;

--- a/test/config/providers/profile_ready_card_visibility_provider_test.dart
+++ b/test/config/providers/profile_ready_card_visibility_provider_test.dart
@@ -3,17 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:whitenoise/config/providers/active_pubkey_provider.dart';
 import 'package:whitenoise/config/providers/profile_ready_card_visibility_provider.dart';
-
-class MockActivePubkeyNotifier extends ActivePubkeyNotifier {
-  final String? _mockValue;
-
-  MockActivePubkeyNotifier(this._mockValue);
-
-  @override
-  String? build() {
-    return _mockValue;
-  }
-}
+import '../../shared/mocks/mock_active_pubkey_notifier.dart';
 
 class _MockFailingSharedPreferences implements SharedPreferences {
   @override

--- a/test/shared/mocks/mock_active_pubkey_notifier.dart
+++ b/test/shared/mocks/mock_active_pubkey_notifier.dart
@@ -1,0 +1,18 @@
+import 'package:whitenoise/config/providers/active_pubkey_provider.dart';
+
+class MockActivePubkeyNotifier extends ActivePubkeyNotifier {
+  String? pubkey;
+
+  MockActivePubkeyNotifier(this.pubkey);
+
+  @override
+  String? build() {
+    return pubkey;
+  }
+
+  @override
+  Future<void> setActivePubkey(String pubkey) async {
+    pubkey = pubkey;
+    state = pubkey;
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
This tiny PR moves a mock class for active pubkey provider that was repeated in 4 test files. I realized when I needed to mock this for 5th time when adding tests to #728 

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [X] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)
