### PR TITLE
feat(rust/src/api/groups): expose created_at, updated_at and mls_group_id on GroupInformation

### DIFF
--- a/lib/src/rust/api/groups.dart
+++ b/lib/src/rust/api/groups.dart
@@ -226,19 +226,31 @@ class Group {
 }
 
 class GroupInformation {
+  final String mlsGroupId;
   final GroupType groupType;
+  final DateTime createdAt;
+  final DateTime updatedAt;
 
   const GroupInformation({
+    required this.mlsGroupId,
     required this.groupType,
+    required this.createdAt,
+    required this.updatedAt,
   });
 
   @override
-  int get hashCode => groupType.hashCode;
+  int get hashCode =>
+      mlsGroupId.hashCode ^ groupType.hashCode ^ createdAt.hashCode ^ updatedAt.hashCode;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is GroupInformation && runtimeType == other.runtimeType && groupType == other.groupType;
+      other is GroupInformation &&
+          runtimeType == other.runtimeType &&
+          mlsGroupId == other.mlsGroupId &&
+          groupType == other.groupType &&
+          createdAt == other.createdAt &&
+          updatedAt == other.updatedAt;
 }
 
 enum GroupState {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -2931,9 +2931,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   GroupInformation dco_decode_group_information(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return GroupInformation(
-      groupType: dco_decode_group_type(arr[0]),
+      mlsGroupId: dco_decode_String(arr[0]),
+      groupType: dco_decode_group_type(arr[1]),
+      createdAt: dco_decode_Chrono_Utc(arr[2]),
+      updatedAt: dco_decode_Chrono_Utc(arr[3]),
     );
   }
 
@@ -3770,8 +3773,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   GroupInformation sse_decode_group_information(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+    final var_mlsGroupId = sse_decode_String(deserializer);
     final var_groupType = sse_decode_group_type(deserializer);
-    return GroupInformation(groupType: var_groupType);
+    final var_createdAt = sse_decode_Chrono_Utc(deserializer);
+    final var_updatedAt = sse_decode_Chrono_Utc(deserializer);
+    return GroupInformation(
+      mlsGroupId: var_mlsGroupId,
+      groupType: var_groupType,
+      createdAt: var_createdAt,
+      updatedAt: var_updatedAt,
+    );
   }
 
   @protected
@@ -4727,7 +4738,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.mlsGroupId, serializer);
     sse_encode_group_type(self.groupType, serializer);
+    sse_encode_Chrono_Utc(self.createdAt, serializer);
+    sse_encode_Chrono_Utc(self.updatedAt, serializer);
   }
 
   @protected

--- a/rust/src/api/groups.rs
+++ b/rust/src/api/groups.rs
@@ -180,14 +180,20 @@ impl From<WhitenoiseGroupType> for GroupType {
 #[frb(non_opaque)]
 #[derive(Debug, Clone)]
 pub struct GroupInformation {
+    pub mls_group_id: String,
     pub group_type: GroupType,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 // Implement conversion from the whitenoise crate's GroupInformation to our GroupInformation
 impl From<WhitenoiseGroupInformation> for GroupInformation {
     fn from(whitenoise_info: WhitenoiseGroupInformation) -> Self {
         Self {
+            mls_group_id: group_id_to_string(&whitenoise_info.mls_group_id),
             group_type: whitenoise_info.group_type.into(),
+            created_at: whitenoise_info.created_at,
+            updated_at: whitenoise_info.updated_at,
         }
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -2962,9 +2962,15 @@ impl SseDecode for crate::api::groups::Group {
 impl SseDecode for crate::api::groups::GroupInformation {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_mlsGroupId = <String>::sse_decode(deserializer);
         let mut var_groupType = <crate::api::groups::GroupType>::sse_decode(deserializer);
+        let mut var_createdAt = <chrono::DateTime<chrono::Utc>>::sse_decode(deserializer);
+        let mut var_updatedAt = <chrono::DateTime<chrono::Utc>>::sse_decode(deserializer);
         return crate::api::groups::GroupInformation {
+            mls_group_id: var_mlsGroupId,
             group_type: var_groupType,
+            created_at: var_createdAt,
+            updated_at: var_updatedAt,
         };
     }
 }
@@ -4071,7 +4077,13 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::groups::Group> for crate::api
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::groups::GroupInformation {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [self.group_type.into_into_dart().into_dart()].into_dart()
+        [
+            self.mls_group_id.into_into_dart().into_dart(),
+            self.group_type.into_into_dart().into_dart(),
+            self.created_at.into_into_dart().into_dart(),
+            self.updated_at.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
@@ -4654,7 +4666,10 @@ impl SseEncode for crate::api::groups::Group {
 impl SseEncode for crate::api::groups::GroupInformation {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.mls_group_id, serializer);
         <crate::api::groups::GroupType>::sse_encode(self.group_type, serializer);
+        <chrono::DateTime<chrono::Utc>>::sse_encode(self.created_at, serializer);
+        <chrono::DateTime<chrono::Utc>>::sse_encode(self.updated_at, serializer);
     }
 }
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Adds the `created_at`, `updated_at` and `mls_group_id` fields on the `GroupInformation`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Groups now include three new data fields: MLS group ID for unique group identification, creation date, and last update date. These additions enhance group resource tracking and improve visibility into each group's complete lifecycle, change history, and key timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->