### PR TITLE
Improve release notes and update zapstore.yaml for release

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -11,6 +11,7 @@
 1. Update the changelog
     1. Change `Unreleased` to version number with date
     1. Create new `Unreleased` section with subsections just above latest version
+1. Update the version path in the zapstore.yaml file.
 1. Run `just precommit` and then commit the changes
 1. Run `just release`. This will do a full check and, rebuild everything from scratch and then produce binaries for each platform.
 1. The binaries will be output to the `build/releases` folder. There will be a folder there named like the version–e.g. `v0.1.4+5`–containing all the binaries and sha256 hash files.

--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -25,4 +25,4 @@ license: AGPL-3.0-only
 blossom_servers:
   - https://cdn.zapstore.dev
 assets:
-  - build/releases/v0.1.4+6/whitenoise-0.1.4-arm64-v8a.apk
+  - build/releases/v0.2.0+7/whitenoise-0.2.0-arm64-v8a.apk


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a release doc step for updating `zapstore.yaml` and bumps the Zapstore asset path to v0.2.0+7.
> 
> - **Docs**:
>   - Add release step to update the version path in `zapstore.yaml` (`docs/release.md`).
> - **Zapstore Config**:
>   - Update `assets` APK path to `build/releases/v0.2.0+7/whitenoise-0.2.0-arm64-v8a.apk` in `zapstore.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d7cbbdace68b6d02f1d69986ee55e86ad84b64c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release workflow documentation with a new configuration step.

* **Chores**
  * Updated asset version configuration to the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->