### PR TITLE
Remove IntrinsicWidth from MessageWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed message bubble width issue where bubbles could become too wide and cause layout problems [#856](https://github.com/parres-hq/whitenoise_flutter/issues/856)
+- Fixed timestamp alignment for received messages to align to the right side instead of left
 ### Security
 
 ## [0.2.1] - 2025-11-20

--- a/lib/ui/chat/widgets/chat_bubble/bubble.dart
+++ b/lib/ui/chat/widgets/chat_bubble/bubble.dart
@@ -25,7 +25,7 @@ class ChatMessageBubble extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Container(
+          ConstrainedBox(
             constraints:
                 constraints ??
                 BoxConstraints(

--- a/lib/ui/chat/widgets/message_widget.dart
+++ b/lib/ui/chat/widgets/message_widget.dart
@@ -108,12 +108,11 @@ class MessageWidget extends StatelessWidget {
   Widget _buildMessageContent(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        return IntrinsicWidth(
+        return ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: constraints.maxWidth,
+          ),
           child: Container(
-            constraints: BoxConstraints(
-              // This allows the bubble to dynamically and correctly adjust its width.
-              maxWidth: constraints.maxWidth,
-            ),
             padding: EdgeInsets.only(
               right: message.isMe ? 8.w : 0,
               left: message.isMe ? 0 : 8.w,
@@ -194,7 +193,7 @@ class MessageWidget extends StatelessWidget {
         return SizedBox(
           width: mediaWidth,
           child: Row(
-            mainAxisAlignment: message.isMe ? MainAxisAlignment.end : MainAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.end,
             children: [
               TimeAndStatus(message: message, context: context),
             ],
@@ -300,7 +299,7 @@ class MessageWidget extends StatelessWidget {
               SizedBox(
                 width: timestampRowWidth,
                 child: Row(
-                  mainAxisAlignment: message.isMe ? MainAxisAlignment.end : MainAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.end,
                   children: [
                     TimeAndStatus(message: message, context: context),
                   ],
@@ -309,7 +308,7 @@ class MessageWidget extends StatelessWidget {
             else
               // Timestamp is wider, it takes only its own width
               Row(
-                mainAxisAlignment: message.isMe ? MainAxisAlignment.end : MainAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.end,
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   TimeAndStatus(message: message, context: context),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
- Fixed message bubble width issue where bubbles could become too wide and cause layout problems.
- Fixed timestamp alignment for received messages to align to the right side instead of left.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Run `just check-flutter-coverage` to ensure that flutter coverage rules are passing
- [x] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)

Fixes #856 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed message bubble width issues where bubbles could extend too wide and cause layout problems
* Fixed timestamp alignment for received messages to consistently align to the right side

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->